### PR TITLE
fix: Remove debugging information

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -83,7 +83,6 @@ fn main() {
         Args { ref arg_command,.. } if !arg_command.is_empty() => {
             match from_stdin() {
                 Some(content) => {
-                   println!("stdin {:?}", content);
                    let watches = Watches::new(rules::from_string(content, arg_command));
                    execute(WatchCommand::new(watches, args.flag_verbose));
                 },


### PR DESCRIPTION
It seems that this was introduced [here](52849555b5c95d7d5f98fb1efb66da4f6a41c528) and forgot even since.

It is a bit weird to see such debugging content when using on daily
basis.
