### PR TITLE
feature: Introduce run_on_init flag

### DIFF
--- a/.watch.yaml
+++ b/.watch.yaml
@@ -7,3 +7,4 @@
 - name: run my test
   run: 'make tests'
   change: 'src/**'
+  run_on_init: true

--- a/README.md
+++ b/README.md
@@ -21,6 +21,11 @@ Configure execution of different commands using semantic yaml.
 - name: Starwars
   run: telnet towel.blinkenlights.nl
   change: '.watch.yaml'
+
+- name: say hello
+  run: say hello
+  change: '.watch.yaml'
+  run_on_init: true
 ```
 
 ## Motivation

--- a/src/cli/watch.rs
+++ b/src/cli/watch.rs
@@ -61,7 +61,6 @@ impl Command for WatchCommand {
             if let DebouncedEvent::Create(path) = event {
                 let path_str  = path.into_os_string().into_string().unwrap();
                 if let Some(shell_commands) = self.watches.watch(&*path_str) {
-
                     if self.verbose { println!("path: {}", path_str) };
 
                     self.run(shell_commands)?
@@ -109,11 +108,11 @@ impl Watches {
     /// Returns the commands for first rule found for the given path
     ///
     pub fn watch(&self, path: &str) -> Option<Vec<String>> {
-        for rule in self.rules.iter()
-            .filter(|r| !r.ignore(path) && r.watch(path)) {
-            return Some(rule.commands());
-        };
-        None
+        self.rules.iter()
+            .filter(|r| !r.ignore(path) && r.watch(path))
+            .map(|r| r.commands())
+            .collect::<Vec<Vec<String>>>()
+            .pop()
     }
 
     /// Returns the commands for the rules that should run on init

--- a/src/cli/watch.rs
+++ b/src/cli/watch.rs
@@ -31,7 +31,6 @@ impl WatchCommand {
 
 impl Command for WatchCommand {
     fn execute(&self) -> Result<(), String> {
-
         let (tx, rx) = channel();
         let mut watcher: RecommendedWatcher = match Watcher::new(tx, Duration::from_secs(2)) {
             Ok(w) => w,
@@ -40,6 +39,16 @@ impl Command for WatchCommand {
 
         if let Err(err) = watcher.watch(".", RecursiveMode::Recursive) {
             panic!("Unable to watch current directory. Cause: {:?}", err)
+        }
+
+        if let Some(shell_commands) = self.watches.run_on_init() {
+            println!("Running on init commands.");
+
+            clear_shell();
+            for command in shell_commands {
+                if self.verbose { println!("command: {:?}", command) };
+                try!(cmd::execute(command))
+            }
         }
 
         println!("Watching.");
@@ -96,8 +105,7 @@ impl Watches {
         Watches { rules: rules::from_yaml(plain_text) }
     }
 
-
-    /// Returns the first rule found for the given path
+    /// Returns the commands for first rule found for the given path
     ///
     pub fn watch(&self, path: &str) -> Option<Vec<String>> {
         for rule in self.rules.iter()
@@ -105,6 +113,18 @@ impl Watches {
             return Some(rule.commands());
         };
         None
+    }
+
+    /// Returns the commands for the rules that should run on init
+    ///
+    pub fn run_on_init(&self) -> Option<Vec<String>> {
+        match self.rules.iter()
+            .filter(|r| r.run_on_init())
+            .flat_map(|r| r.commands())
+            .collect::<Vec<String>>().as_slice() {
+                [] => None,
+                v => Some(v.to_vec()),
+            }
     }
 }
 
@@ -246,5 +266,34 @@ mod tests {
         assert!(watches.watch("src/test.txt").is_some());
         assert!(watches.watch("src/tmp/test.txt").is_none());
         assert!(watches.watch("src/test/other.tmp").is_none())
+    }
+
+    #[test]
+    fn it_returns_on_init_rules() {
+        let file_content = "
+            - name: my source
+              run: 'cargo build'
+              change: 'src/**'
+              run_on_init: true
+
+            - name: my source
+              run: ['cat foo', 'cat bar']
+              change: 'src/**'
+              run_on_init: true
+
+            - name: other
+              run: 'cargo test'
+              change: 'test/**'
+            ";
+        let watches = Watches::from(file_content);
+
+        assert_eq!(
+            watches.run_on_init().unwrap(),
+            vec![
+                "cargo build".to_string(),
+                "cat foo".to_string(),
+                "cat bar".to_string(),
+            ]
+        );
     }
 }

--- a/src/cli/watch.rs
+++ b/src/cli/watch.rs
@@ -27,6 +27,15 @@ impl WatchCommand {
         if verbose { println!("watches {:?}", watches); }
         WatchCommand { watches: watches , verbose: verbose }
     }
+
+    fn run(&self, commands: Vec<String>) -> Result<(), String> {
+        clear_shell();
+        for command in commands {
+            if self.verbose { println!("command: {:?}", command) };
+            try!(cmd::execute(command))
+        }
+        Ok(())
+    }
 }
 
 impl Command for WatchCommand {
@@ -44,11 +53,7 @@ impl Command for WatchCommand {
         if let Some(shell_commands) = self.watches.run_on_init() {
             println!("Running on init commands.");
 
-            clear_shell();
-            for command in shell_commands {
-                if self.verbose { println!("command: {:?}", command) };
-                try!(cmd::execute(command))
-            }
+            self.run(shell_commands)?
         }
 
         println!("Watching.");
@@ -59,11 +64,7 @@ impl Command for WatchCommand {
 
                     if self.verbose { println!("path: {}", path_str) };
 
-                    clear_shell();
-                    for command in shell_commands {
-                        if self.verbose { println!("command: {:?}", command) };
-                        try!(cmd::execute(command))
-                    }
+                    self.run(shell_commands)?
                 }
             }
         }

--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -26,7 +26,6 @@ fn command_parser(command: String) -> Vec<Command> {
 }
 
 pub fn execute(command_line: String) -> Result<(), String> {
-
     let commands = command_parser(command_line);
 
     for mut cmd in commands {

--- a/src/yaml.rs
+++ b/src/yaml.rs
@@ -15,6 +15,17 @@ pub fn extract_strings(yaml: &Yaml) -> Vec<String> {
     }
 }
 
+/// It tries to find a boolean otherwise if defaults to false
+///
+pub fn extract_bool(yaml: &Yaml) -> bool {
+    match yaml.clone() {
+        Yaml::Boolean(item) => {
+            item
+        },
+        _ => false,
+    }
+}
+
 pub fn validate(yaml: &Yaml, key: &str) {
     if yaml[key].is_badvalue() {
         println!("File has a bad format. (Key {} not found)", key);


### PR DESCRIPTION
Run the rule's commands once before when flag with "run_on_init".

e.g.:

- name: run my test
  run: 'make tests'
  change: 'src/**'
  run_on_init: true

This would run the `make tests` once on start, even if nothing changed,
and then start the watcher.

The flag is set to false by default, if the key is not present on the
yaml or if values can't be assumed.