### PR TITLE
fix: watcher process don't die on task fail

### DIFF
--- a/src/cmd.rs
+++ b/src/cmd.rs
@@ -9,7 +9,8 @@ pub fn execute(command_line: String) -> Result<(), String> {
             if status.success() {
                 return Ok(());
             } else {
-                return Err(String::from("Command failed"));
+                println!("This task command has failed {}", status);
+                return Ok(());
             }
         }
     };

--- a/tests/integration/specs/watcher-does-not-die.sh
+++ b/tests/integration/specs/watcher-does-not-die.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+source "$HELPERS"
+test "process does not die when a one or more commands fail (list)"
+
+echo "
+- name: run the list and do not die
+  run: [
+    'echo before',
+    'exit 1',
+    'cat foo/bar/baz',
+    'exit 125',
+    'echo after'
+  ]
+  change: \"$WORKDIR/**\"
+  run_on_init: true
+" > $WORKDIR/.dontdie.yaml
+
+funzzy --config $WORKDIR/.dontdie.yaml > $WORKDIR/output.txt &
+FUNZZY_PID=$!
+
+wait_for_file "$WORKDIR/output.txt"
+assert_file_contains "$WORKDIR/output.txt" "funzzy running: echo before"
+assert_file_contains "$WORKDIR/output.txt" "funzzy running: exit 1"
+assert_file_contains "$WORKDIR/output.txt" "This task command has failed exit status: 1"
+assert_file_contains "$WORKDIR/output.txt" "funzzy running: cat foo/bar/baz"
+assert_file_contains "$WORKDIR/output.txt" "funzzy running: exit 125"
+assert_file_contains "$WORKDIR/output.txt" "This task command has failed exit status: 125"
+assert_file_contains "$WORKDIR/output.txt" "funzzy running: echo after"
+
+cleanup
+
+test "process does not die when a task fail (multiple tasks)"
+
+echo "
+- name: run the first task
+  run: 'echo before'
+  change: \"$WORKDIR/**\"
+  run_on_init: true
+
+- name: run the first task
+  run: 'cat baz/bar/foo'
+  change: \"$WORKDIR/**\"
+  run_on_init: true
+
+- name: run finally
+  run: 'echo finally'
+  change: \"$WORKDIR/**\"
+  run_on_init: true
+" > $WORKDIR/.dontdie.yaml
+
+funzzy --config $WORKDIR/.dontdie.yaml > $WORKDIR/output.txt &
+FUNZZY_PID=$!
+
+wait_for_file "$WORKDIR/output.txt"
+assert_file_contains "$WORKDIR/output.txt" "funzzy running: echo before"
+assert_file_contains "$WORKDIR/output.txt" "funzzy running: cat baz/bar/foo"
+assert_file_contains "$WORKDIR/output.txt" "This task command has failed exit status: 1"
+assert_file_contains "$WORKDIR/output.txt" "funzzy running: echo finally"
+
+cleanup


### PR DESCRIPTION
  Upon a failed task the watcher shows a error message
  but continue to run the tasks and watch for changes

Fixes https://github.com/cristianoliveira/funzzy/issues/57