### PR TITLE
chore: fix formatting after lint

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -95,11 +95,7 @@ fn main() {
                         Err(err) => error("Failed to get rules from stdin", err),
                     };
 
-                    execute_watch_command(
-                        Watches::new(watch_rules),
-                        args.flag_n,
-                        args.flag_V,
-                    );
+                    execute_watch_command(Watches::new(watch_rules), args.flag_n, args.flag_V);
                 }
                 Err(err) => error("Failed to read stdin", err),
             };
@@ -110,10 +106,12 @@ fn main() {
                 let default_filename = cli::watch::DEFAULT_FILENAME;
                 match rules::from_file(default_filename) {
                     Ok(rules) => rules,
-                    Err(err) => match rules::from_file(&default_filename.replace(".yaml", ".yml")) {
-                        Ok(rules) => rules,
-                        Err(_) => error("Failed to read default config file", err),
-                    },
+                    Err(err) => {
+                        match rules::from_file(&default_filename.replace(".yaml", ".yml")) {
+                            Ok(rules) => rules,
+                            Err(_) => error("Failed to read default config file", err),
+                        }
+                    }
                 }
             } else {
                 match rules::from_file(&args.flag_config) {
@@ -131,20 +129,17 @@ fn main() {
 
                 if filtered.is_empty() {
                     let mut output = String::new();
-                    output.push_str(&format!(
-                            "No target found for '{}'\n\n",
-                            args.flag_target
-                            ));
+                    output.push_str(&format!("No target found for '{}'\n\n", args.flag_target));
                     output.push_str("Available targets:\n");
                     output.push_str(&format!(
-                            "  {}\n",
-                            rules
+                        "  {}\n",
+                        rules
                             .iter()
                             .cloned()
                             .map(|r| r.name)
                             .collect::<Vec<String>>()
                             .join("\n  ")
-                            ));
+                    ));
 
                     stdout::info(output.as_str());
 
@@ -194,7 +189,7 @@ fn from_stdin() -> Result<String, String> {
         Ok(bytes) => {
             let mut has_input_mutex = match has_input.lock() {
                 Ok(mutex) => mutex,
-                Err(err) =>  {
+                Err(err) => {
                     return Err(format!("Could not lock stdin mutex {}", err));
                 }
             };

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -92,10 +92,7 @@ pub fn from_yaml(file_content: &str) -> Result<Vec<Rules>, String> {
     let items = match YamlLoader::load_from_str(file_content) {
         Ok(val) => val,
         Err(err) => {
-            return Err(format!(
-                "Found an invalid yaml format {}",
-                err
-            ));
+            return Err(format!("Found an invalid yaml format {}", err));
         }
     };
     match items[0] {
@@ -108,10 +105,7 @@ pub fn from_string(patterns: String, command: String) -> Result<Vec<Rules>, Stri
     let current_dir = match std::env::current_dir() {
         Ok(val) => val,
         Err(err) => {
-            return Err(format!(
-                "Failed to get current directory {}",
-                err
-            ));
+            return Err(format!("Failed to get current directory {}", err));
         }
     };
 
@@ -134,7 +128,10 @@ pub fn from_string(patterns: String, command: String) -> Result<Vec<Rules>, Stri
                 let full_path_as_str = match full_path.join("**").to_str() {
                     Some(val) => val.to_owned(),
                     None => {
-                        println!("Warning: Was not possible to convert {} to absolute path", line);
+                        println!(
+                            "Warning: Was not possible to convert {} to absolute path",
+                            line
+                        );
 
                         String::from("")
                     }
@@ -146,7 +143,10 @@ pub fn from_string(patterns: String, command: String) -> Result<Vec<Rules>, Stri
             match full_path.to_str() {
                 Some(val) => val.to_owned(),
                 None => {
-                    println!("Warning: Was not possible to convert {} to absolute path", line);
+                    println!(
+                        "Warning: Was not possible to convert {} to absolute path",
+                        line
+                    );
 
                     String::from("")
                 }

--- a/src/yaml.rs
+++ b/src/yaml.rs
@@ -28,7 +28,10 @@ pub fn extract_bool(yaml: &Yaml) -> bool {
 
 pub fn validate(yaml: &Yaml, key: &str) {
     if yaml[key].is_badvalue() {
-        println!("Config file has an invalid format. (Key {} was not found)", key);
+        println!(
+            "Config file has an invalid format. (Key {} was not found)",
+            key
+        );
         panic!("Interrupted due the previou error.")
     }
 }


### PR DESCRIPTION
(cherry picked from commit 703b9bf73ac64bbf3128c4652b2facaeb2ba95eb)