### PR TITLE
fix: fail to run on init when {{filepath}}

### DIFF
--- a/examples/tasks-with-filepath-template.yml
+++ b/examples/tasks-with-filepath-template.yml
@@ -1,11 +1,10 @@
 - name: replaces {{filepath}} with changed file path
   run:
     - "echo 'this file has changed: {{filepath}}'"
-    - "cat {{filepath}}"
+    - "cat '{{filepath}}' || echo 'nothing to run'"
   change: "examples/workdir/**/*"
   ignore: "examples/workdir/ignored/**/*.txt"
-  # FIXME it fails when running on init
-  # run_on_init: true
+  run_on_init: true
 
 - name: more advanced usage of {{filepath}}
   run:
@@ -14,5 +13,4 @@
   ignore: 
     - "examples/workdir/ignored/**/*.txt"
     - "examples/workdir/another_ignored_file.foo"
-  # FIXME it fails when running on init
-  # run_on_init: true
+  run_on_init: true

--- a/src/cli/watch.rs
+++ b/src/cli/watch.rs
@@ -32,7 +32,7 @@ impl Command for WatchCommand {
         if let Some(rules) = self.watches.run_on_init() {
             stdout::info("Running on init commands.");
 
-            let results = rules::commands(rules)
+            let results = rules::template(rules::commands(rules), "")
                 .iter()
                 .map(cmd::execute)
                 .collect::<Vec<Result<(), String>>>();

--- a/tests/tasks_with_filepath_template.rs
+++ b/tests/tasks_with_filepath_template.rs
@@ -25,7 +25,8 @@ fn test_it_replaces_filepath_template_with_changed_file() {
                         .read_to_string(&mut output)
                         .expect("failed to read from file");
 
-                    output.contains("Watching...")
+                    output.contains("Running on init commands.")
+                        && output.contains("Funzzy results")
                 },
                 "Funzzy has not been started with verbose mode {}",
                 output
@@ -48,7 +49,22 @@ fn test_it_replaces_filepath_template_with_changed_file() {
             );
 
             let dir = std::env::current_dir().expect("failed to get current dir");
-            let expected = "Funzzy: Watching...
+            let expected = "Funzzy: Running on init commands.
+
+Funzzy: echo 'this file has changed: ' 
+
+this file has changed: 
+
+Funzzy: cat '' || echo 'nothing to run' 
+
+nothing to run
+
+Funzzy: echo '' | sed -r s/trigger/foobar/ 
+
+
+Funzzy results ----------------------------
+All tasks finished successfully.
+Funzzy: Watching...
 
 Funzzy: clear 
 
@@ -57,7 +73,7 @@ Funzzy: echo 'this file has changed: $PWD/examples/workdir/trigger-watcher.txt'
 
 this file has changed: $PWD/examples/workdir/trigger-watcher.txt
 
-Funzzy: cat $PWD/examples/workdir/trigger-watcher.txt 
+Funzzy: cat '$PWD/examples/workdir/trigger-watcher.txt' || echo 'nothing to run' 
 
 test_content
 


### PR DESCRIPTION
Now it replaces file path with empty so in order to avoid failing one must check if the value is empty. Example: `run: "cat '{{filepath}}' || echo 'empty'"`

fixes https://github.com/cristianoliveira/funzzy/issues/103