### PR TITLE
chore(lint): address all warnings

### DIFF
--- a/src/cli/watch_non_block.rs
+++ b/src/cli/watch_non_block.rs
@@ -1,7 +1,6 @@
 extern crate notify;
 
 use crate::cli::Command;
-use crate::cmd;
 use crate::stdout;
 use crate::watcher;
 use crate::watches::Watches;

--- a/src/workers.rs
+++ b/src/workers.rs
@@ -40,7 +40,7 @@ impl Worker {
                 stdout::verbose(&format!("ignored kill: {:?}", ignored), verbose);
 
                 let mut has_been_cancelled = false;
-                let mut time_execution_started = std::time::Instant::now();
+                let time_execution_started = std::time::Instant::now();
 
                 for task in tasks {
                     if has_been_cancelled

--- a/tests/common/lib.rs
+++ b/tests/common/lib.rs
@@ -11,6 +11,7 @@ use std::{
 
 use crate::defer;
 
+#[allow(dead_code)]
 pub struct Options {
     pub output_file: &'static str,
     pub example_file: &'static str,
@@ -18,8 +19,10 @@ pub struct Options {
 
 static IS_RUNNING_MULTITHREAD: std::sync::Mutex<u8> = std::sync::Mutex::new(0);
 
+#[allow(dead_code)]
 pub const CLEAR_SCREEN: &str = "[2J";
 
+#[allow(dead_code)]
 pub fn with_example<F>(opts: Options, handler: F) -> ()
 where
     F: FnOnce(&mut Command, File) -> (),
@@ -80,6 +83,7 @@ where
         .expect("failed to remove file after running test");
 }
 
+#[allow(dead_code)]
 pub fn with_output<F>(output_file_path: &str, handler: F) -> ()
 where
     F: FnOnce(&mut Command, File) -> (),
@@ -137,6 +141,7 @@ where
         .expect("failed to remove file after running test");
 }
 
+#[allow(dead_code)]
 pub fn clean_output(output_file: &str) -> String {
     output_file
         .lines()

--- a/tests/watching_arbitrary_files_running_arbitrary_commands.rs
+++ b/tests/watching_arbitrary_files_running_arbitrary_commands.rs
@@ -1,4 +1,3 @@
-use std::fs::File;
 use std::io::prelude::*;
 use std::process::{Command, Stdio};
 


### PR DESCRIPTION
(cherry picked from commit f1618dd7e19c7a0fe1b0c7c320d0f1bb9e58dc7c)