### PR TITLE
feat: adds configuration with environment variables

### DIFF
--- a/examples/invalid/invalid-value.yml
+++ b/examples/invalid/invalid-value.yml
@@ -1,0 +1,10 @@
+- name: correct with run_on_init
+  run: echo hello
+  run_on_init: true
+
+- name: correct with change
+  run: echo hello
+  change: **/hello/*
+
+- foo: bla # "name" is required
+  run: bar

--- a/src/main.rs
+++ b/src/main.rs
@@ -56,6 +56,11 @@ Options:
   -h --help               Show this message.
   -v --version            Show version.
   -V                      Use verbose output.
+
+Environment configs:
+
+FUNZZY_NON_BLOCK: Boolean   Same as `--non-block`
+FUNZZY_BAIL: Boolean        Same as `--fail-fast`
 ";
 
 #[allow(non_snake_case)]
@@ -209,8 +214,9 @@ pub fn execute_watch_command(watches: Watches, args: Args) {
     });
 
     let verbose = args.flag_V;
-    let fail_fast = args.flag_fail_fast;
-    if args.flag_non_block {
+    let fail_fast = args.flag_fail_fast || std::env::var("FUNZZY_BAIL").is_ok();
+    let fail_fast_env = args.flag_non_block || std::env::var("FUNZZY_NON_BLOCK").is_ok();
+    if fail_fast_env {
         execute(WatchNonBlockCommand::new(watches, verbose, fail_fast))
     } else {
         execute(WatchCommand::new(watches, verbose, fail_fast))

--- a/tests/watching_with_fail_fast_flag.rs
+++ b/tests/watching_with_fail_fast_flag.rs
@@ -91,6 +91,93 @@ Funzzy: finished in 0.0s",
 }
 
 #[test]
+fn test_when_using_fail_fast_exit_before_with_env() {
+    setup::with_example(
+        setup::Options {
+            example_file: "examples/list-of-failing-commands.yml",
+            output_file: "test_when_using_fail_fast_exit_before_with_env.log",
+        },
+        |fzz_cmd, mut output_file| {
+            let mut output = String::new();
+            let mut child = fzz_cmd
+                .env("FUNZZY_BAIL", "1")
+                .spawn()
+                .expect("failed to spawn sub process");
+            defer!({
+                child.kill().expect("failed to kill sub process");
+            });
+
+            wait_until!({
+                output_file
+                    .read_to_string(&mut output)
+                    .expect("failed to read test output file");
+
+                output.contains("Funzzy results") && output.contains("Failed tasks: 1")
+            });
+
+            assert_eq!(
+                setup::clean_output(&output),
+                "Funzzy: Running on init commands.
+
+Funzzy: echo complex | sed s/complex/third/g 
+
+third
+
+Funzzy: cat baz/bar/foo 
+
+Funzzy results ----------------------------
+Failed tasks: 1
+ - Command cat baz/bar/foo has failed with exit status: 1
+Funzzy: finished in 0.0s"
+            );
+
+            write_to_file!("examples/workdir/trigger-watcher.txt");
+
+            wait_until!({
+                output_file
+                    .read_to_string(&mut output)
+                    .expect("failed to read test output file");
+
+                output.match_indices("Funzzy results").count() == 2
+            });
+
+            assert_eq!(
+                setup::clean_output(&output),
+                "Funzzy: Running on init commands.
+
+Funzzy: echo complex | sed s/complex/third/g 
+
+third
+
+Funzzy: cat baz/bar/foo 
+
+Funzzy results ----------------------------
+Failed tasks: 1
+ - Command cat baz/bar/foo has failed with exit status: 1
+Funzzy: finished in 0.0s
+[2J
+Funzzy: echo complex | sed s/complex/third/g 
+
+third
+
+Funzzy: echo before 
+
+before
+
+Funzzy: exit 1 
+
+Funzzy results ----------------------------
+Failed tasks: 1
+ - Command exit 1 has failed with exit status: 1
+Funzzy: finished in 0.0s",
+                "failed to match ouput: {}",
+                output
+            );
+        },
+    );
+}
+
+#[test]
 fn test_fail_fast_with_non_block() {
     setup::with_example(
         setup::Options {

--- a/tests/watching_with_non_block_flag.rs
+++ b/tests/watching_with_non_block_flag.rs
@@ -98,3 +98,97 @@ Long task running... 0
         },
     );
 }
+
+#[test]
+fn test_it_cancel_current_running_task_when_something_change_with_env() {
+    setup::with_example(
+        setup::Options {
+            output_file: "test_it_cancel_current_running_task_when_something_change_with_env.log",
+            example_file: "examples/tasks-with-long-running-commands.yaml",
+        },
+        |fzz_cmd, mut output_log| {
+            let mut child = fzz_cmd
+                .env("FUNZZY_NON_BLOCK", "true")
+                .spawn()
+                .expect("failed to spawn child");
+
+            defer!({
+                child.kill().expect("failed to kill child");
+            });
+
+            let mut output = String::new();
+            wait_until!(
+                {
+                    output_log
+                        .read_to_string(&mut output)
+                        .expect("failed to read from file");
+
+                    output.contains("Running on init commands")
+                        && output.contains("Started task long 2")
+                },
+                "No task in the example was configured with run_on_init {}",
+                output
+            );
+
+            write_to_file!("examples/workdir/trigger-watcher.txt");
+            // This should not trigger another restart
+            write_to_file!("examples/workdir/another_ignored_file.foo");
+
+            wait_until!(
+                {
+                    output_log
+                        .read_to_string(&mut output)
+                        .expect("failed to read from file");
+
+                    // See it in `examples/longtask.sh`
+                    // and also in `src/stdout.rs`
+                    output.match_indices(CLEAR_SCREEN).count() == 1
+                },
+                "Failed to find a clear screen sign: {}",
+                output
+            );
+
+            write_to_file!("examples/workdir/trigger-watcher.txt");
+
+            wait_until!(
+                {
+                    output_log
+                        .read_to_string(&mut output)
+                        .expect("failed to read from file");
+
+                    // See it in `examples/longtask.sh`
+                    // and also in `src/stdout.rs`
+                    output.match_indices(CLEAR_SCREEN).count() == 2
+                },
+                "Failed to find 2 clear screen signs: {}",
+                output
+            );
+
+            let expected = "Funzzy: Running on init commands.
+
+Funzzy: bash examples/longtask.sh long 2 
+
+Started task long 2
+Long task running... 0
+
+[2J
+Funzzy: bash examples/longtask.sh long 1 
+
+Started task long 1
+Long task running... 0
+
+[2J
+Funzzy: bash examples/longtask.sh long 1 
+
+Started task long 1
+Long task running... 0
+";
+
+            assert_eq!(
+                output, expected,
+                "Output:\n{} ------ \n\nExpected:\n{}",
+                output, expected,
+            );
+        },
+    );
+}


### PR DESCRIPTION
Allows setting up funzzy behaviour with environment variable example:
```bash
export FUNZZY_BAIL=1 
export FUNZZY_NON_BLOCK=1
fzz # same as `fzz -nb`
```