### PR TITLE
feat(stdout): messages now has colours

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -605,9 +605,9 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
-version = "2.0.79"
+version = "2.0.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89132cd0bf050864e1d38dc3bbc07a0eb8e7530af26344d3d2bbbef83499f590"
+checksum = "198514704ca887dd5a1e408c6c6cdcba43672f9b4062e1b24aa34e74e6d7faae"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/nix/package-local.nix
+++ b/nix/package-local.nix
@@ -2,7 +2,7 @@
 
 rustPlatform.buildRustPackage {
   pname = "funzzy";
-  version = "3c707df";
+  version = "5a163ba";
 
   ## build with local source
   src = ../.;
@@ -18,7 +18,7 @@ rustPlatform.buildRustPackage {
 #   allowBuiltinFetchGit = true;
 # };
 
-  cargoHash = "sha256-MOOl+cfjubuoRwwLkZ7vnATehYVEqfBJUezvpV+lvK0=";
+  cargoHash = "sha256-AWmWEaojQjz9duqGav1R8nb/pOsAlG7RTSb5mxDpWiM=";
 
   buildInputs = lib.optionals stdenv.isDarwin [
     darwin.apple_sdk.frameworks.CoreServices

--- a/shell.nix
+++ b/shell.nix
@@ -5,7 +5,7 @@
 pkgs.mkShell {
   packages = with pkgs; [
     ## funzzy local
-    srcpkgs.local
+    # srcpkgs.local
 
     rustc
     cargo

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -3,8 +3,14 @@ use std::fmt;
 
 use yaml_rust::ScanError;
 
+use crate::stdout;
+
 pub type Hint = Option<String>;
 pub type Result<T> = std::result::Result<T, FzzError>;
+
+fn hint_formatter(hint: &str) -> String {
+    format!("{}Hint{}: {}", stdout::BLUE, stdout::RESET, hint)
+}
 
 #[derive(Debug)]
 pub enum FzzError {
@@ -20,11 +26,11 @@ impl fmt::Display for FzzError {
             FzzError::IoConfigError(msg, Some(err)) => match err.kind() {
                 std::io::ErrorKind::NotFound => {
                     let hints = "Check if the file exists and if the path is correct";
-                    write!(f, "{}\nReason: {}\nHint: {}", msg, err, hints)
+                    write!(f, "{}\nReason: {}\n{}", msg, err, hint_formatter(hints))
                 }
                 std::io::ErrorKind::PermissionDenied => {
                     let hints = "Check if you have permission to write in the current folder";
-                    write!(f, "{}\nReason: {}\nHint: {}", msg, err, hints)
+                    write!(f, "{}\nReason: {}\n{}", msg, err, hint_formatter(hints))
                 }
                 _ => write!(f, "{}\nReason: {}", msg, err),
             },
@@ -33,7 +39,7 @@ impl fmt::Display for FzzError {
             }
             FzzError::IoStdinError(err, hints) => {
                 if let Some(hints) = hints {
-                    write!(f, "Reason: {}\nHint: {}", err, hints)
+                    write!(f, "Reason: {}\n{}", err, hint_formatter(hints))
                 } else {
                     write!(f, "Reason: {}", err)
                 }
@@ -45,7 +51,7 @@ impl fmt::Display for FzzError {
                 };
 
                 if let Some(hints) = hints {
-                    write!(f, "{}{}\nHint: {}", msg, err, hints)
+                    write!(f, "{}{}\n{}", msg, err, hint_formatter(hints))
                 } else {
                     write!(f, "{}{}", msg, err)
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -293,11 +293,11 @@ fn get_version() -> String {
 
 fn show(text: &str) -> ! {
     println!("{}", text);
-    std::process::exit(0);
+    std::process::exit(0)
 }
 
 fn error(text: &str, err: String) -> ! {
-    println!("Error: {}", text);
+    println!("{}Error{}: {}", stdout::RED, stdout::RESET, text);
     println!("{}", err);
-    std::process::exit(1);
+    std::process::exit(1)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -59,8 +59,9 @@ Options:
 
 Environment configs:
 
-FUNZZY_NON_BLOCK: Boolean   Same as `--non-block`
-FUNZZY_BAIL: Boolean        Same as `--fail-fast`
+FUNZZY_NON_BLOCK: Boolean        Same as `--non-block`
+FUNZZY_BAIL: Boolean             Same as `--fail-fast`
+FUNZZY_RESULT_COLORED: Boolean   Output results with colors.
 ";
 
 #[allow(non_snake_case)]

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -422,8 +422,10 @@ mod tests {
     use self::yaml_rust::YamlLoader;
     use super::from_string;
     use super::from_yaml;
+    use super::rule_from;
     use super::{commands, template};
-    use super::{rule_from, Rules};
+
+    use crate::stdout;
     use std::env::current_dir;
 
     #[test]
@@ -726,7 +728,7 @@ mod tests {
                 "|>          change: **/*",
                 "|         ",
                 "Reason: while scanning an anchor or alias, did not find expected alphabetic or numeric character at line 8 column 19",
-                "Hint: Check for wrong types, any missing quotes for glob pattern or incorrect identation",
+                &format!("{}Hint{}: Check for wrong types, any missing quotes for glob pattern or incorrect identation", stdout::BLUE, stdout::RESET),
             ]
             .join("\n")
         );
@@ -740,7 +742,7 @@ mod tests {
             result.err().unwrap().to_string(),
             vec![
                 "Configuration file is invalid! There are no rules to watch",
-                "Hint: Make sure to declare at least one rule. Try to run `fzz init` to generate a new configuration from scratch"
+                &format!("{}Hint{}: Make sure to declare at least one rule. Try to run `fzz init` to generate a new configuration from scratch", stdout::BLUE, stdout::RESET),
             ]
             .join("\n")
         );
@@ -762,7 +764,11 @@ mod tests {
                 "  - name: foo",
                 "    run: echo foo",
                 "```",
-                "Hint: Make sure to declare the rules as a list without any root property",
+                &format!(
+                    "{}Hint{}: Make sure to declare the rules as a list without any root property",
+                    stdout::BLUE,
+                    stdout::RESET
+                ),
             ]
             .join("\n")
         );

--- a/src/stdout.rs
+++ b/src/stdout.rs
@@ -1,20 +1,27 @@
 use std::io::Write;
 
+// ANSI color codes for terminal output
+pub const GREEN: &str = "\x1b[32m";
+pub const RED: &str = "\x1b[31m";
+pub const YELLOW: &str = "\x1b[33m";
+pub const BLUE: &str = "\x1b[34m";
+pub const RESET: &str = "\x1b[0m";
+
 pub fn info(msg: &str) {
-    println!("Funzzy: {}", msg);
+    println!("{}Funzzy{}: {}", BLUE, RESET, msg);
 }
 
 pub fn pinfo(msg: &str) {
-    print!("Funzzy: {}", msg);
+    print!("{}Funzzy{}: {}", BLUE, RESET, msg);
     std::io::stdout().flush().expect("Failed to flush stdout");
 }
 
 pub fn error(msg: &str) {
-    println!("Funzzy error: {}", msg);
+    println!("{}Funzzy error{}: {}", RED, RESET, msg);
 }
 
 pub fn warn(msg: &str) {
-    println!("Funzzy warning: {}", msg);
+    println!("{}Funzzy warning{}: {}", YELLOW, RESET, msg);
 }
 
 pub fn verbose(msg: &str, verbose: bool) {
@@ -31,13 +38,16 @@ pub fn present_results(results: Vec<Result<(), String>>) {
     let errors: Vec<Result<(), String>> = results.iter().cloned().filter(|r| r.is_err()).collect();
     println!("Funzzy results ----------------------------");
     if !errors.is_empty() {
+        println!("{}", RED);
         println!("Failed tasks: {:?}", errors.len());
         errors.iter().for_each(|err| {
             println!(" - {}", err.as_ref().unwrap_err());
         });
     } else {
+        println!("{}", GREEN);
         println!("All tasks finished successfully.");
     }
+    println!("{}", RESET);
 }
 
 pub fn clear_screen() -> () {

--- a/src/stdout.rs
+++ b/src/stdout.rs
@@ -3,25 +3,29 @@ use std::io::Write;
 // ANSI color codes for terminal output
 pub const GREEN: &str = "\x1b[32m";
 pub const RED: &str = "\x1b[31m";
-pub const YELLOW: &str = "\x1b[33m";
 pub const BLUE: &str = "\x1b[34m";
 pub const RESET: &str = "\x1b[0m";
 
+fn is_color_enabled() -> bool {
+    // Colour output is not enabled by default
+    std::env::var("FUNZZY_RESULT_COLORED").is_ok()
+}
+
 pub fn info(msg: &str) {
-    println!("{}Funzzy{}: {}", BLUE, RESET, msg);
+    println!("Funzzy: {}", msg);
 }
 
 pub fn pinfo(msg: &str) {
-    print!("{}Funzzy{}: {}", BLUE, RESET, msg);
+    print!("Funzzy: {}", msg);
     std::io::stdout().flush().expect("Failed to flush stdout");
 }
 
 pub fn error(msg: &str) {
-    println!("{}Funzzy error{}: {}", RED, RESET, msg);
+    println!("{}Funzzy error{}: {}",RED, RESET, msg);
 }
 
 pub fn warn(msg: &str) {
-    println!("{}Funzzy warning{}: {}", YELLOW, RESET, msg);
+    println!("Funzzy warning: {}", msg);
 }
 
 pub fn verbose(msg: &str, verbose: bool) {
@@ -38,16 +42,23 @@ pub fn present_results(results: Vec<Result<(), String>>) {
     let errors: Vec<Result<(), String>> = results.iter().cloned().filter(|r| r.is_err()).collect();
     println!("Funzzy results ----------------------------");
     if !errors.is_empty() {
-        println!("{}", RED);
+        if is_color_enabled() {
+            print!("{}", RED);
+        }
         println!("Failed tasks: {:?}", errors.len());
         errors.iter().for_each(|err| {
             println!(" - {}", err.as_ref().unwrap_err());
         });
     } else {
-        println!("{}", GREEN);
+        if is_color_enabled() {
+            print!("{}", GREEN);
+        }
         println!("All tasks finished successfully.");
     }
-    println!("{}", RESET);
+
+    if is_color_enabled() {
+        print!("{}", RESET);
+    }
 }
 
 pub fn clear_screen() -> () {

--- a/src/stdout.rs
+++ b/src/stdout.rs
@@ -21,7 +21,7 @@ pub fn pinfo(msg: &str) {
 }
 
 pub fn error(msg: &str) {
-    println!("{}Funzzy error{}: {}",RED, RESET, msg);
+    println!("{}Funzzy error{}: {}", RED, RESET, msg);
 }
 
 pub fn warn(msg: &str) {

--- a/src/yaml.rs
+++ b/src/yaml.rs
@@ -166,6 +166,7 @@ pub fn yaml_to_string(yaml: &Yaml, identation: u8) -> String {
 mod tests {
     use self::yaml_rust::YamlLoader;
     use super::*;
+    use crate::stdout;
 
     fn clean_yaml_str(yaml_str: &str) -> String {
         yaml_str
@@ -219,7 +220,8 @@ fooobar:
             Err(err) => {
                 assert_eq!(
                     format!("{}", err),
-                    "Invalid property 'fooobar' in rule below
+                    format!(
+                        "Invalid property 'fooobar' in rule below
 Expected a list (Array) but got: Hash
 ```yaml
 fooobar:
@@ -232,7 +234,10 @@ fooobar:
     - bar
     - baz
 ```
-Hint: Check if the property is defined, with the right type and identation"
+{}Hint{}: Check if the property is defined, with the right type and identation",
+                        stdout::BLUE,
+                        stdout::RESET
+                    ),
                 );
             }
         }

--- a/tests/command_init_errors.rs
+++ b/tests/command_init_errors.rs
@@ -21,7 +21,7 @@ fn it_fails_when_config_file_alredy_exists() -> Result<(), Box<dyn std::error::E
         let mut cmd = Command::cargo_bin(BINARY_NAME)?;
         cmd.arg("init").assert().failure().stdout(
             vec![
-                "Error: Command failed to execute",
+                "\u{1b}[31mError\u{1b}[0m: Command failed to execute",
                 "Configuration file already exists (.watch.yaml)",
                 "",
             ]
@@ -53,10 +53,10 @@ fn it_fails_folder_is_read_only() -> Result<(), Box<dyn std::error::Error>> {
 
         cmd.arg("init").assert().failure().stdout(
             vec![
-                "Error: Command failed to execute",
+                "\u{1b}[31mError\u{1b}[0m: Command failed to execute",
                 "Failed to create the configuration file",
                 "Reason: Permission denied (os error 13)",
-                "Hint: Check if you have permission to write in the current folder",
+                "\u{1b}[34mHint\u{1b}[0m: Check if you have permission to write in the current folder",
                 "",
             ]
             .join("\n"),

--- a/tests/read_stdin_error.rs
+++ b/tests/read_stdin_error.rs
@@ -15,9 +15,9 @@ fn it_fails_when_no_stdin_is_given() -> Result<(), Box<dyn std::error::Error>> {
         .failure()
         .stdout(
             vec![
-                "Error: Failed to read stdin",
+                "\u{1b}[31mError\u{1b}[0m: Failed to read stdin",
                 "Reason: Timed out waiting for input.",
-                "Hint: Did you forget to pipe an output of a command? Try `find . | fzz 'echo \"changed: {{filepath}}\"'`",
+                "\u{1b}[34mHint\u{1b}[0m: Did you forget to pipe an output of a command? Try `find . | fzz 'echo \"changed: {{filepath}}\"'`",
                 "",
             ]
             .join("\n"),

--- a/tests/tasks_that_run_on_init.rs
+++ b/tests/tasks_that_run_on_init.rs
@@ -5,6 +5,10 @@ mod setup;
 
 #[test]
 fn test_it_executes_tasks_on_init_when_configured() {
+    std::env::set_var("FUNZZY_RESULT_COLORED", "1");
+    defer!({
+        std::env::remove_var("FUNZZY_RESULT_COLORED");
+    });
     setup::with_example(
         setup::Options {
             output_file: "test_it_executes_tasks_on_init_when_configured.log",
@@ -47,7 +51,7 @@ Funzzy: echo \"only run on init\"
 
 only run on init
 Funzzy results ----------------------------
-All tasks finished successfully.
+\u{1b}[32mAll tasks finished successfully.
 Funzzy: finished in 0.0s"
             );
 

--- a/tests/watching_configured_errors.rs
+++ b/tests/watching_configured_errors.rs
@@ -19,10 +19,10 @@ fn it_fails_when_folder_is_read_only() -> Result<(), Box<dyn std::error::Error>>
     let mut cmd = Command::cargo_bin(BINARY_NAME)?;
     cmd.assert().failure().stdout(
         vec![
-            "Error: Failed to read default config file",
+            "\u{1b}[31mError\u{1b}[0m: Failed to read default config file",
             "Couldn\'t open configuration file: \'.watch.yaml\'",
             "Reason: No such file or directory (os error 2)",
-            "Hint: Check if the file exists and if the path is correct",
+            "\u{1b}[34mHint\u{1b}[0m: Check if the file exists and if the path is correct",
             "",
         ]
         .join("\n"),
@@ -42,13 +42,13 @@ fn it_fails_using_an_config_with_missing_properties() -> Result<(), Box<dyn std:
         .failure()
         .stdout(
             vec![
-                "Error: Failed to read config file",
+                "\u{1b}[31mError\u{1b}[0m: Failed to read config file",
                 "Missing \'name\' in rule",
                 "```yaml",
                 "foo: bla",
                 "run: bar",
                 "```",
-                "Hint: Check for typos or wrong identation",
+                "\u{1b}[34mHint\u{1b}[0m: Check for typos or wrong identation",
                 "",
             ]
             .join("\n"),
@@ -68,7 +68,7 @@ fn it_fails_using_an_config_with_non_list() -> Result<(), Box<dyn std::error::Er
         .failure()
         .stdout(
             vec![
-                "Error: Failed to read config file",
+                "\u{1b}[31mError\u{1b}[0m: Failed to read config file",
                 "Configuration file is invalid. Expected an Array/List of rules got: Hash",
                 "```yaml",
                 "on:",
@@ -76,7 +76,7 @@ fn it_fails_using_an_config_with_non_list() -> Result<(), Box<dyn std::error::Er
                 "    run: echo hello",
                 "    change: hello/*",
                 "```",
-                "Hint: Make sure to declare the rules as a list without any root property",
+                "\u{1b}[34mHint\u{1b}[0m: Make sure to declare the rules as a list without any root property",
                 "",
             ]
             .join("\n"),


### PR DESCRIPTION
Here how it is now:

<img width="888" alt="Screenshot 2024-10-20 at 17 00 46" src="https://github.com/user-attachments/assets/a5509904-a07c-45b6-b16f-a214b0565f75">

When using `FUNZZY_RESULT_COLORED=1`
<img width="888" alt="Screenshot 2024-10-20 at 16 04 22" src="https://github.com/user-attachments/assets/47bb6efe-e92e-46f4-9c6e-b47245a9ebbb">

<img width="888" alt="Screenshot 2024-10-20 at 16 03 25" src="https://github.com/user-attachments/assets/bb8dbe14-729a-43db-920d-039b2997695a">



