### PR TITLE
feat(flags): allows --target empty to list available

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ test-integration-file-system = []
 test-integration = []
 
 [dependencies]
-docopt = "1"
+docopt = "1.1.1"
 serde = "1.0" # if you're using `derive(Deserialize)`
 serde_derive = "1.0" # if you're using `derive(Deserialize)`
 notify = "4.0.0"

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -89,6 +89,7 @@ impl Error for FzzError {
     fn source(&self) -> Option<&(dyn Error + 'static)> {
         match self {
             FzzError::IoConfigError(_, Some(e)) => Some(e),
+            FzzError::PathError(_, Some(e), _) => Some(e.as_ref()),
             _ => None,
         }
     }

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -444,6 +444,21 @@ pub fn validate_rules(rule: &Vec<Rules>) -> Result<(), String> {
     Ok(())
 }
 
+pub fn available_targets(rules: Vec<Rules>) -> String {
+    let mut output = String::new();
+    output.push_str("Available tasks\n");
+    output.push_str(&format!(
+        "  - {}\n",
+        rules
+            .iter()
+            .cloned()
+            .map(|r| r.name)
+            .collect::<Vec<String>>()
+            .join("\n  - ")
+    ));
+    output
+}
+
 #[cfg(test)]
 mod tests {
     extern crate yaml_rust;


### PR DESCRIPTION
Allows `--target` to have a similar behavior as `cargo test --test` which lists the available tests to use