### PR TITLE
feat(flags): add `--no-run-on-init` flag to control initial task exec…

### DIFF
--- a/docs/FLAG_NO_RUN_INIT.md
+++ b/docs/FLAG_NO_RUN_INIT.md
@@ -1,0 +1,48 @@
+## FLAG: `--no-run-on-init` 
+
+Tasks configured with `run_on_init: true` are executed when the watcher starts. By default, this behavior is enabled.
+By using the `--no-run-on-init` flag, you can disable this behavior and prevent tasks from running on initialization.
+The remaining triggers will still work as expected. It does not filter the tasks.
+
+## USAGE
+
+Given the following config file:
+```yaml
+- name: a task that does not run on init
+  run: "echo 'should not run on init'"
+  change: "examples/workdir/**/*"
+  ignore:
+    - "examples/workdir/ignored/**/*.txt"
+    - "examples/workdir/another_ignored_file.foo"
+
+- name: a task that runs on init
+  run: "echo 'should run on init'"
+  change: "examples/workdir/**/*"
+  ignore:
+    - "examples/workdir/ignored/**/*.txt"
+    - "examples/workdir/another_ignored_file.foo"
+  run_on_init: true
+```
+
+When running `fzz` without the `--no-run-on-init` flag, the output will be:
+
+```bash
+$ fzz
+should run on init
+Funzzy: Running on init commands.
+// run tasks...
+
+```
+
+When running `fzz` with the `--no-run-on-init` flag, the output will be:
+
+```bash
+$ fzz --no-run-on-init
+Funzzy: Watching...
+```
+
+The remaingin triggers work as expected, so if you change the file `examples/workdir/trigger-watcher.txt` the task will run.
+
+### Tests
+
+Check the tests in `tests/ignore_run_on_init.rs` for more details.

--- a/src/cli/watch.rs
+++ b/src/cli/watch.rs
@@ -31,7 +31,6 @@ impl WatchCommand {
             run_on_init,
         }
     }
-
 }
 
 impl Command for WatchCommand {

--- a/src/cli/watch_non_block.rs
+++ b/src/cli/watch_non_block.rs
@@ -31,7 +31,6 @@ impl WatchNonBlockCommand {
             run_on_init,
         }
     }
-
 }
 
 impl Command for WatchNonBlockCommand {

--- a/src/cli/watch_non_block.rs
+++ b/src/cli/watch_non_block.rs
@@ -17,18 +17,21 @@ pub struct WatchNonBlockCommand {
     watches: Watches,
     verbose: bool,
     fail_fast: bool,
+    run_on_init: bool,
 }
 
 impl WatchNonBlockCommand {
-    pub fn new(watches: Watches, verbose: bool, fail_fast: bool) -> Self {
+    pub fn new(watches: Watches, verbose: bool, fail_fast: bool, run_on_init: bool) -> Self {
         stdout::verbose(&format!("watches {:?}", watches), verbose);
 
         WatchNonBlockCommand {
             watches,
             verbose,
             fail_fast,
+            run_on_init,
         }
     }
+
 }
 
 impl Command for WatchNonBlockCommand {
@@ -45,9 +48,13 @@ impl Command for WatchNonBlockCommand {
         });
 
         if let Some(rules) = self.watches.run_on_init() {
-            stdout::info("Running on init commands.");
-            if let Err(err) = worker.schedule(rules, "") {
-                stdout::error(&format!("failed to initiate next run: {:?}", err));
+            if self.run_on_init {
+                stdout::info("Running on init commands.");
+                if let Err(err) = worker.schedule(rules, "") {
+                    stdout::error(&format!("failed to initiate next run: {:?}", err));
+                }
+            } else {
+                stdout::info("Watching...");
             }
         } else {
             stdout::info("Watching...");

--- a/src/main.rs
+++ b/src/main.rs
@@ -87,7 +87,6 @@ pub struct Args {
 
     pub flag_non_block: bool,
     pub flag_no_run_on_init: bool,
-    pub flag_no_run_on_init: bool,
     pub flag_fail_fast: bool,
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -55,6 +55,7 @@ Options:
   -t --target <name>      Execute only the given task target (if empty list availables).
   -n --non-block          Execute tasks and cancel them if a new event is received.
   -b --fail-fast          Bail current execution if a task fails (exit code != 0).
+  --no-run-on-init        Do not run tasks on initialization.
   -h --help               Show this message.
   -v --version            Show version.
   -V                      Use verbose output.
@@ -85,6 +86,7 @@ pub struct Args {
     pub flag_V: bool,
 
     pub flag_non_block: bool,
+    pub flag_no_run_on_init: bool,
     pub flag_no_run_on_init: bool,
     pub flag_fail_fast: bool,
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -85,6 +85,7 @@ pub struct Args {
     pub flag_V: bool,
 
     pub flag_non_block: bool,
+    pub flag_no_run_on_init: bool,
     pub flag_fail_fast: bool,
 }
 
@@ -274,10 +275,11 @@ pub fn execute_watch_command(watches: Watches, args: Args) {
     let verbose = args.flag_V;
     let fail_fast = args.flag_fail_fast || environment::is_enabled("FUNZZY_BAIL");
     let fail_fast_env = args.flag_non_block || environment::is_enabled("FUNZZY_NON_BLOCK");
+    let run_on_init = !args.flag_no_run_on_init;
     if fail_fast_env {
-        execute(WatchNonBlockCommand::new(watches, verbose, fail_fast))
+        execute(WatchNonBlockCommand::new(watches, verbose, fail_fast, run_on_init))
     } else {
-        execute(WatchCommand::new(watches, verbose, fail_fast))
+        execute(WatchCommand::new(watches, verbose, fail_fast, run_on_init))
     }
 
     let _ = th.join().expect("Failed to join config watcher thread");

--- a/src/main.rs
+++ b/src/main.rs
@@ -278,7 +278,12 @@ pub fn execute_watch_command(watches: Watches, args: Args) {
     let fail_fast_env = args.flag_non_block || environment::is_enabled("FUNZZY_NON_BLOCK");
     let run_on_init = !args.flag_no_run_on_init;
     if fail_fast_env {
-        execute(WatchNonBlockCommand::new(watches, verbose, fail_fast, run_on_init))
+        execute(WatchNonBlockCommand::new(
+            watches,
+            verbose,
+            fail_fast,
+            run_on_init,
+        ))
     } else {
         execute(WatchCommand::new(watches, verbose, fail_fast, run_on_init))
     }

--- a/tests/tasks_that_run_on_init.rs
+++ b/tests/tasks_that_run_on_init.rs
@@ -1,159 +1,143 @@
 use std::collections::HashMap;
 use std::io::prelude::*;
 
-use pretty_assertions::assert_eq;
+// use pretty_assertions::assert_eq;
 
 #[path = "./common/lib.rs"]
 mod setup;
 
 #[test]
 fn test_it_executes_tasks_on_init_when_configured() {
-    setup::with_env(
-        HashMap::from([("FUNZZY_COLORED".to_string(), "1".to_string())]),
-        || {
-            setup::with_example(
-                setup::Options {
-                    output_file: "test_it_executes_tasks_on_init_when_configured.log",
-                    example_file: "examples/list-of-tasks-run-on-init.yml",
+    setup::with_example(
+        setup::Options {
+            output_file: "test_it_executes_tasks_on_init_when_configured.log",
+            example_file: "examples/list-of-tasks-run-on-init.yml",
+        },
+        |fzz_cmd, mut output_log| {
+            let mut child = fzz_cmd.spawn().expect("failed to spawn child");
+
+            defer!({
+                child.kill().expect("failed to kill child");
+            });
+
+            let mut output = String::new();
+
+            wait_until!(
+                {
+                    output_log
+                        .read_to_string(&mut output)
+                        .expect("failed to read from file");
+
+                    output.contains("Funzzy results")
                 },
-                |fzz_cmd, mut output_log| {
-                    let mut child = fzz_cmd.spawn().expect("failed to spawn child");
+                "No task in the example was configured with run_on_init {}",
+                output
+            );
 
-                    defer!({
-                        child.kill().expect("failed to kill child");
-                    });
+            assert_eq!(
+                setup::clean_output(&output),
+                "Funzzy: Running on init commands.
 
-                    let mut output = String::new();
-
-                    wait_until!(
-                        {
-                            output_log
-                                .read_to_string(&mut output)
-                                .expect("failed to read from file");
-
-                            output.contains("Funzzy results")
-                        },
-                        "No task in the example was configured with run_on_init {}",
-                        output
-                    );
-
-                    assert_eq!(
-                        setup::clean_output(&output),
-                        "\u{1b}[34mFunzzy\u{1b}[0m: Running on init commands.
-
-\u{1b}[34mFunzzy\u{1b}[0m: echo 'running on init first' 
+Funzzy: echo 'running on init first' 
 
 running on init first
 
-\u{1b}[34mFunzzy\u{1b}[0m: echo \"run on init sencod\" 
+Funzzy: echo \"run on init sencod\" 
 
 run on init sencod
 
-\u{1b}[34mFunzzy\u{1b}[0m: echo \"only run on init\" 
+Funzzy: echo \"only run on init\" 
 
 only run on init
 Funzzy results ----------------------------
-\u{1b}[32mSuccess\u{1b}[0m; Completed: 3; Failed: 0; Durantion: 0.0000s"
-                    );
-
-                    write_to_file!("examples/workdir/trigger-watcher.txt");
-
-                    wait_until!(
-                        {
-                            output_log
-                                .read_to_string(&mut output)
-                                .expect("failed to read from file");
-
-                            output.contains("should not run on init but on change")
-                        },
-                        "OUTPUT: {}",
-                        output
-                    );
-                },
+Success; Completed: 3; Failed: 0; Durantion: 0.0000s"
             );
 
-            Ok(())
+            // FIXME: this should not be needed sleep 5s
+            std::thread::sleep(std::time::Duration::from_secs(5));
+            write_to_file!("examples/workdir/trigger-watcher.txt");
+
+            wait_until!(
+                {
+                    output_log
+                        .read_to_string(&mut output)
+                        .expect("failed to read from file");
+
+                    output.contains("should not run on init but on change")
+                },
+                "OUTPUT: {}",
+                output
+            );
         },
     )
-    .expect("failed to run test");
 }
 
 #[test]
 fn test_it_does_not_executes_tasks_on_init_when_no_run_on_init_flag() {
-    setup::with_env(
-        HashMap::from([("FUNZZY_COLORED".to_string(), "1".to_string())]),
-        || {
-            setup::with_example(
-                setup::Options {
-                    output_file:
-                        "test_it_does_not_executes_tasks_on_init_when_no_run_on_init_flag.log",
-                    example_file: "examples/list-of-tasks-run-on-init.yml",
+    setup::with_example(
+        setup::Options {
+            output_file: "test_it_does_not_executes_tasks_on_init_when_no_run_on_init_flag.log",
+            example_file: "examples/list-of-tasks-run-on-init.yml",
+        },
+        |fzz_cmd, mut output_log| {
+            let mut child = fzz_cmd
+                .arg("--no-run-on-init")
+                .spawn()
+                .expect("failed to spawn child");
+
+            defer!({
+                child.kill().expect("failed to kill child");
+            });
+
+            let mut output = String::new();
+
+            wait_until!(
+                {
+                    output_log
+                        .read_to_string(&mut output)
+                        .expect("failed to read from file");
+
+                    !output.contains("Running on init commands") && output.contains("Watching...")
                 },
-                |fzz_cmd, mut output_log| {
-                    let mut child = fzz_cmd
-                        .arg("--no-run-on-init")
-                        .spawn()
-                        .expect("failed to spawn child");
+                "No task in the example was configured with run_on_init {}",
+                output
+            );
 
-                    defer!({
-                        child.kill().expect("failed to kill child");
-                    });
+            // FIXME: this should not be needed sleep 5s
+            std::thread::sleep(std::time::Duration::from_secs(5));
+            write_to_file!("examples/workdir/trigger-watcher.txt");
 
-                    let mut output = String::new();
+            wait_until!(
+                {
+                    output_log
+                        .read_to_string(&mut output)
+                        .expect("failed to read from file");
 
-                    wait_until!(
-                        {
-                            output_log
-                                .read_to_string(&mut output)
-                                .expect("failed to read from file");
+                    output.contains("should not run on init but on change")
+                },
+                "OUTPUT: {}",
+                output
+            );
 
-                            !output.contains("Running on init commands")
-                                && output.contains("Watching...")
-                        },
-                        "No task in the example was configured with run_on_init {}",
-                        output
-                    );
-
-                    // FIXME: this should not be needed sleep 5s
-                    std::thread::sleep(std::time::Duration::from_secs(5));
-                    write_to_file!("examples/workdir/trigger-watcher.txt");
-
-                    wait_until!(
-                        {
-                            output_log
-                                .read_to_string(&mut output)
-                                .expect("failed to read from file");
-
-                            output.contains("should not run on init but on change")
-                        },
-                        "OUTPUT: {}",
-                        output
-                    );
-
-                    assert_eq!(
-                        setup::clean_output(&output),
-                        "\u{1b}[34mFunzzy\u{1b}[0m: Watching...
+            assert_eq!(
+                setup::clean_output(&output),
+                "Funzzy: Watching...
 
 [2J
-\u{1b}[34mFunzzy\u{1b}[0m: echo 'running on init first' 
+Funzzy: echo 'running on init first' 
 
 running on init first
 
-\u{1b}[34mFunzzy\u{1b}[0m: echo \"should not run on init but on change\" 
+Funzzy: echo \"should not run on init but on change\" 
 
 should not run on init but on change
 
-\u{1b}[34mFunzzy\u{1b}[0m: echo \"run on init sencod\" 
+Funzzy: echo \"run on init sencod\" 
 
 run on init sencod
 Funzzy results ----------------------------
-\u{1b}[32mSuccess\u{1b}[0m; Completed: 3; Failed: 0; Durantion: 0.0000s"
-                    );
-                },
+Success; Completed: 3; Failed: 0; Durantion: 0.0000s"
             );
-
-            Ok(())
         },
     )
-    .expect("failed to run test");
 }

--- a/tests/tasks_that_run_on_init.rs
+++ b/tests/tasks_that_run_on_init.rs
@@ -77,3 +77,78 @@ Funzzy results ----------------------------
     )
     .expect("failed to run test");
 }
+
+#[test]
+fn test_it_does_not_executes_tasks_on_init_when_no_run_on_init_flag() {
+    setup::with_env(
+        HashMap::from([("FUNZZY_COLORED".to_string(), "1".to_string())]),
+        || {
+            setup::with_example(
+                setup::Options {
+                    output_file: "test_it_executes_tasks_on_init_when_configured.log",
+                    example_file: "examples/list-of-tasks-run-on-init.yml",
+                },
+                |fzz_cmd, mut output_log| {
+                    let mut child = fzz_cmd
+                        .arg("--no-run-on-init")
+                        .spawn().expect("failed to spawn child");
+
+                    defer!({
+                        child.kill().expect("failed to kill child");
+                    });
+
+                    let mut output = String::new();
+
+                    wait_until!(
+                        {
+                            output_log
+                                .read_to_string(&mut output)
+                                .expect("failed to read from file");
+
+                            !output.contains("Funzzy: Running on init commands.") &&
+                            output.contains("Funzzy: Watching...")
+                        },
+                        "No task in the example was configured with run_on_init {}",
+                        output
+                    );
+
+                    assert_eq!(
+                        setup::clean_output(&output),
+                        "\u{1b}[34mFunzzy\u{1b}[0m: Watching...
+
+\u{1b}[34mFunzzy\u{1b}[0m: echo 'running on init first' 
+
+running on init first
+
+\u{1b}[34mFunzzy\u{1b}[0m: echo \"run on init sencod\" 
+
+run on init sencod
+
+\u{1b}[34mFunzzy\u{1b}[0m: echo \"only run on init\" 
+
+only run on init
+Funzzy results ----------------------------
+\u{1b}[32mSuccess\u{1b}[0m; Completed: 3; Failed: 0; Durantion: 0.0000s"
+                    );
+
+                    write_to_file!("examples/workdir/trigger-watcher.txt");
+
+                    wait_until!(
+                        {
+                            output_log
+                                .read_to_string(&mut output)
+                                .expect("failed to read from file");
+
+                            output.contains("should not run on init but on change")
+                        },
+                        "OUTPUT: {}",
+                        output
+                    );
+                },
+            );
+
+            Ok(())
+        },
+    )
+    .expect("failed to run test");
+}

--- a/tests/tasks_that_run_on_init.rs
+++ b/tests/tasks_that_run_on_init.rs
@@ -85,7 +85,8 @@ fn test_it_does_not_executes_tasks_on_init_when_no_run_on_init_flag() {
         || {
             setup::with_example(
                 setup::Options {
-                    output_file: "test_it_does_not_executes_tasks_on_init_when_no_run_on_init_flag.log",
+                    output_file:
+                        "test_it_does_not_executes_tasks_on_init_when_no_run_on_init_flag.log",
                     example_file: "examples/list-of-tasks-run-on-init.yml",
                 },
                 |fzz_cmd, mut output_log| {

--- a/tests/tasks_that_run_on_init.rs
+++ b/tests/tasks_that_run_on_init.rs
@@ -91,7 +91,8 @@ fn test_it_does_not_executes_tasks_on_init_when_no_run_on_init_flag() {
                 |fzz_cmd, mut output_log| {
                     let mut child = fzz_cmd
                         .arg("--no-run-on-init")
-                        .spawn().expect("failed to spawn child");
+                        .spawn()
+                        .expect("failed to spawn child");
 
                     defer!({
                         child.kill().expect("failed to kill child");
@@ -105,8 +106,8 @@ fn test_it_does_not_executes_tasks_on_init_when_no_run_on_init_flag() {
                                 .read_to_string(&mut output)
                                 .expect("failed to read from file");
 
-                            !output.contains("Funzzy: Running on init commands.") &&
-                            output.contains("Funzzy: Watching...")
+                            !output.contains("Funzzy: Running on init commands.")
+                                && output.contains("Funzzy: Watching...")
                         },
                         "No task in the example was configured with run_on_init {}",
                         output

--- a/tests/tasks_that_run_on_init.rs
+++ b/tests/tasks_that_run_on_init.rs
@@ -1,143 +1,79 @@
 use std::collections::HashMap;
 use std::io::prelude::*;
 
-// use pretty_assertions::assert_eq;
+use pretty_assertions::assert_eq;
 
 #[path = "./common/lib.rs"]
 mod setup;
 
 #[test]
 fn test_it_executes_tasks_on_init_when_configured() {
-    setup::with_example(
-        setup::Options {
-            output_file: "test_it_executes_tasks_on_init_when_configured.log",
-            example_file: "examples/list-of-tasks-run-on-init.yml",
-        },
-        |fzz_cmd, mut output_log| {
-            let mut child = fzz_cmd.spawn().expect("failed to spawn child");
-
-            defer!({
-                child.kill().expect("failed to kill child");
-            });
-
-            let mut output = String::new();
-
-            wait_until!(
-                {
-                    output_log
-                        .read_to_string(&mut output)
-                        .expect("failed to read from file");
-
-                    output.contains("Funzzy results")
+    setup::with_env(
+        HashMap::from([("FUNZZY_COLORED".to_string(), "1".to_string())]),
+        || {
+            setup::with_example(
+                setup::Options {
+                    output_file: "test_it_executes_tasks_on_init_when_configured.log",
+                    example_file: "examples/list-of-tasks-run-on-init.yml",
                 },
-                "No task in the example was configured with run_on_init {}",
-                output
-            );
+                |fzz_cmd, mut output_log| {
+                    let mut child = fzz_cmd.spawn().expect("failed to spawn child");
 
-            assert_eq!(
-                setup::clean_output(&output),
-                "Funzzy: Running on init commands.
+                    defer!({
+                        child.kill().expect("failed to kill child");
+                    });
 
-Funzzy: echo 'running on init first' 
+                    let mut output = String::new();
+
+                    wait_until!(
+                        {
+                            output_log
+                                .read_to_string(&mut output)
+                                .expect("failed to read from file");
+
+                            output.contains("Funzzy results")
+                        },
+                        "No task in the example was configured with run_on_init {}",
+                        output
+                    );
+
+                    assert_eq!(
+                        setup::clean_output(&output),
+                        "\u{1b}[34mFunzzy\u{1b}[0m: Running on init commands.
+
+\u{1b}[34mFunzzy\u{1b}[0m: echo 'running on init first' 
 
 running on init first
 
-Funzzy: echo \"run on init sencod\" 
+\u{1b}[34mFunzzy\u{1b}[0m: echo \"run on init sencod\" 
 
 run on init sencod
 
-Funzzy: echo \"only run on init\" 
+\u{1b}[34mFunzzy\u{1b}[0m: echo \"only run on init\" 
 
 only run on init
 Funzzy results ----------------------------
-Success; Completed: 3; Failed: 0; Durantion: 0.0000s"
-            );
+\u{1b}[32mSuccess\u{1b}[0m; Completed: 3; Failed: 0; Durantion: 0.0000s"
+                    );
 
-            // FIXME: this should not be needed sleep 5s
-            std::thread::sleep(std::time::Duration::from_secs(5));
-            write_to_file!("examples/workdir/trigger-watcher.txt");
+                    write_to_file!("examples/workdir/trigger-watcher.txt");
 
-            wait_until!(
-                {
-                    output_log
-                        .read_to_string(&mut output)
-                        .expect("failed to read from file");
+                    wait_until!(
+                        {
+                            output_log
+                                .read_to_string(&mut output)
+                                .expect("failed to read from file");
 
-                    output.contains("should not run on init but on change")
+                            output.contains("should not run on init but on change")
+                        },
+                        "OUTPUT: {}",
+                        output
+                    );
                 },
-                "OUTPUT: {}",
-                output
             );
+
+            Ok(())
         },
     )
-}
-
-#[test]
-fn test_it_does_not_executes_tasks_on_init_when_no_run_on_init_flag() {
-    setup::with_example(
-        setup::Options {
-            output_file: "test_it_does_not_executes_tasks_on_init_when_no_run_on_init_flag.log",
-            example_file: "examples/list-of-tasks-run-on-init.yml",
-        },
-        |fzz_cmd, mut output_log| {
-            let mut child = fzz_cmd
-                .arg("--no-run-on-init")
-                .spawn()
-                .expect("failed to spawn child");
-
-            defer!({
-                child.kill().expect("failed to kill child");
-            });
-
-            let mut output = String::new();
-
-            wait_until!(
-                {
-                    output_log
-                        .read_to_string(&mut output)
-                        .expect("failed to read from file");
-
-                    !output.contains("Running on init commands") && output.contains("Watching...")
-                },
-                "No task in the example was configured with run_on_init {}",
-                output
-            );
-
-            // FIXME: this should not be needed sleep 5s
-            std::thread::sleep(std::time::Duration::from_secs(5));
-            write_to_file!("examples/workdir/trigger-watcher.txt");
-
-            wait_until!(
-                {
-                    output_log
-                        .read_to_string(&mut output)
-                        .expect("failed to read from file");
-
-                    output.contains("should not run on init but on change")
-                },
-                "OUTPUT: {}",
-                output
-            );
-
-            assert_eq!(
-                setup::clean_output(&output),
-                "Funzzy: Watching...
-
-[2J
-Funzzy: echo 'running on init first' 
-
-running on init first
-
-Funzzy: echo \"should not run on init but on change\" 
-
-should not run on init but on change
-
-Funzzy: echo \"run on init sencod\" 
-
-run on init sencod
-Funzzy results ----------------------------
-Success; Completed: 3; Failed: 0; Durantion: 0.0000s"
-            );
-        },
-    )
+    .expect("failed to run test");
 }

--- a/tests/tasks_that_run_on_init.rs
+++ b/tests/tasks_that_run_on_init.rs
@@ -85,7 +85,7 @@ fn test_it_does_not_executes_tasks_on_init_when_no_run_on_init_flag() {
         || {
             setup::with_example(
                 setup::Options {
-                    output_file: "test_it_executes_tasks_on_init_when_configured.log",
+                    output_file: "test_it_does_not_executes_tasks_on_init_when_no_run_on_init_flag.log",
                     example_file: "examples/list-of-tasks-run-on-init.yml",
                 },
                 |fzz_cmd, mut output_log| {
@@ -106,32 +106,15 @@ fn test_it_does_not_executes_tasks_on_init_when_no_run_on_init_flag() {
                                 .read_to_string(&mut output)
                                 .expect("failed to read from file");
 
-                            !output.contains("Funzzy: Running on init commands.")
-                                && output.contains("Funzzy: Watching...")
+                            !output.contains("Running on init commands")
+                                && output.contains("Watching...")
                         },
                         "No task in the example was configured with run_on_init {}",
                         output
                     );
 
-                    assert_eq!(
-                        setup::clean_output(&output),
-                        "\u{1b}[34mFunzzy\u{1b}[0m: Watching...
-
-\u{1b}[34mFunzzy\u{1b}[0m: echo 'running on init first' 
-
-running on init first
-
-\u{1b}[34mFunzzy\u{1b}[0m: echo \"run on init sencod\" 
-
-run on init sencod
-
-\u{1b}[34mFunzzy\u{1b}[0m: echo \"only run on init\" 
-
-only run on init
-Funzzy results ----------------------------
-\u{1b}[32mSuccess\u{1b}[0m; Completed: 3; Failed: 0; Durantion: 0.0000s"
-                    );
-
+                    // FIXME: this should not be needed sleep 5s
+                    std::thread::sleep(std::time::Duration::from_secs(5));
                     write_to_file!("examples/workdir/trigger-watcher.txt");
 
                     wait_until!(
@@ -144,6 +127,26 @@ Funzzy results ----------------------------
                         },
                         "OUTPUT: {}",
                         output
+                    );
+
+                    assert_eq!(
+                        setup::clean_output(&output),
+                        "\u{1b}[34mFunzzy\u{1b}[0m: Watching...
+
+[2J
+\u{1b}[34mFunzzy\u{1b}[0m: echo 'running on init first' 
+
+running on init first
+
+\u{1b}[34mFunzzy\u{1b}[0m: echo \"should not run on init but on change\" 
+
+should not run on init but on change
+
+\u{1b}[34mFunzzy\u{1b}[0m: echo \"run on init sencod\" 
+
+run on init sencod
+Funzzy results ----------------------------
+\u{1b}[32mSuccess\u{1b}[0m; Completed: 3; Failed: 0; Durantion: 0.0000s"
                     );
                 },
             );


### PR DESCRIPTION
…ution

Summary:
This commit introduces a new command-line flag `--no-run-on-init` that allows users to disable the automatic execution of tasks configured with `run_on_init: true` when the watcher starts.

Detailed Changes:
- `docs/FLAG_NO_RUN_INIT.md`: Added documentation explaining the behavior and usage of the new `--no-run-on-init` flag.
- `src/cli/watch.rs`: Updated the `WatchCommand` struct and the `new` method to include the `run_on_init` flag. Modified logic to check the `run_on_init` condition.
- `src/cli/watch_non_block.rs`: Updated the `WatchNonBlockCommand` struct and the `new` method to include the `run_on_init` flag. Altered logic to respect the `run_on_init` condition.
- `src/main.rs`: Modified the `Args` struct to include `flag_no_run_on_init`. Updated `execute_watch_command` to handle the new flag and pass it to the `WatchCommand` or `WatchNonBlockCommand`.
- `tests/tasks_that_run_on_init.rs`: Added a new test `test_it_does_not_executes_tasks_on_init_when_no_run_on_init_flag` to ensure tasks do not run on initialization when the flag is set.

closes #236 