### PR TITLE
feat(flags): add `--no-run-on-init` flag to control initial task exec

### DIFF
--- a/docs/FLAG_NO_RUN_INIT.md
+++ b/docs/FLAG_NO_RUN_INIT.md
@@ -1,0 +1,48 @@
+## FLAG: `--no-run-on-init` 
+
+Tasks configured with `run_on_init: true` are executed when the watcher starts. By default, this behavior is enabled.
+By using the `--no-run-on-init` flag, you can disable this behavior and prevent tasks from running on initialization.
+The remaining triggers will still work as expected. It does not filter the tasks.
+
+## USAGE
+
+Given the following config file:
+```yaml
+- name: a task that does not run on init
+  run: "echo 'should not run on init'"
+  change: "examples/workdir/**/*"
+  ignore:
+    - "examples/workdir/ignored/**/*.txt"
+    - "examples/workdir/another_ignored_file.foo"
+
+- name: a task that runs on init
+  run: "echo 'should run on init'"
+  change: "examples/workdir/**/*"
+  ignore:
+    - "examples/workdir/ignored/**/*.txt"
+    - "examples/workdir/another_ignored_file.foo"
+  run_on_init: true
+```
+
+When running `fzz` without the `--no-run-on-init` flag, the output will be:
+
+```bash
+$ fzz
+should run on init
+Funzzy: Running on init commands.
+// run tasks...
+
+```
+
+When running `fzz` with the `--no-run-on-init` flag, the output will be:
+
+```bash
+$ fzz --no-run-on-init
+Funzzy: Watching...
+```
+
+The remaingin triggers work as expected, so if you change the file `examples/workdir/trigger-watcher.txt` the task will run.
+
+### Tests
+
+Check the tests in `tests/ignore_run_on_init.rs` for more details.

--- a/docs/FLAG_NO_RUN_INIT.md
+++ b/docs/FLAG_NO_RUN_INIT.md
@@ -28,7 +28,6 @@ When running `fzz` without the `--no-run-on-init` flag, the output will be:
 
 ```bash
 $ fzz
-should run on init
 Funzzy: Running on init commands.
 // run tasks...
 

--- a/src/cli/watch.rs
+++ b/src/cli/watch.rs
@@ -17,16 +17,18 @@ pub struct WatchCommand {
     watches: Watches,
     verbose: bool,
     fail_fast: bool,
+    run_on_init: bool,
 }
 
 impl WatchCommand {
-    pub fn new(watches: Watches, verbose: bool, fail_fast: bool) -> Self {
+    pub fn new(watches: Watches, verbose: bool, fail_fast: bool, run_on_init: bool) -> Self {
         stdout::verbose(&format!("watches {:?}", watches), verbose);
 
         WatchCommand {
             watches,
             verbose,
             fail_fast,
+            run_on_init,
         }
     }
 }
@@ -37,32 +39,36 @@ impl Command for WatchCommand {
 
         let current_dir = std::env::current_dir().unwrap();
 
-        if let Some(rules) = self.watches.run_on_init() {
-            let time_execution_started = std::time::Instant::now();
+        if self.run_on_init {
+            if let Some(rules) = self.watches.run_on_init() {
+                let time_execution_started = std::time::Instant::now();
 
-            stdout::info("Running on init commands.");
+                stdout::info("Running on init commands.");
 
-            let tasks = rules::template(
-                rules::commands(rules),
-                rules::TemplateOptions {
-                    filepath: None,
-                    current_dir: format!("{}", current_dir.display()),
-                },
-            );
-            let mut results: Vec<Result<(), String>> = vec![];
-            for task in tasks {
-                let result = cmd::execute(&task);
+                let tasks = rules::template(
+                    rules::commands(rules),
+                    rules::TemplateOptions {
+                        filepath: None,
+                        current_dir: format!("{}", current_dir.display()),
+                    },
+                );
+                let mut results: Vec<Result<(), String>> = vec![];
+                for task in tasks {
+                    let result = cmd::execute(&task);
 
-                if self.fail_fast && result.is_err() {
+                    if self.fail_fast && result.is_err() {
+                        results.push(result);
+                        break;
+                    }
+
                     results.push(result);
-                    break;
                 }
 
-                results.push(result);
+                let time_elapsed = time_execution_started.elapsed();
+                stdout::present_results(results, time_elapsed);
+            } else {
+                stdout::info("Watching...");
             }
-
-            let time_elapsed = time_execution_started.elapsed();
-            stdout::present_results(results, time_elapsed);
         } else {
             stdout::info("Watching...");
         }

--- a/src/cli/watch_non_block.rs
+++ b/src/cli/watch_non_block.rs
@@ -17,16 +17,18 @@ pub struct WatchNonBlockCommand {
     watches: Watches,
     verbose: bool,
     fail_fast: bool,
+    run_on_init: bool,
 }
 
 impl WatchNonBlockCommand {
-    pub fn new(watches: Watches, verbose: bool, fail_fast: bool) -> Self {
+    pub fn new(watches: Watches, verbose: bool, fail_fast: bool, run_on_init: bool) -> Self {
         stdout::verbose(&format!("watches {:?}", watches), verbose);
 
         WatchNonBlockCommand {
             watches,
             verbose,
             fail_fast,
+            run_on_init,
         }
     }
 }
@@ -45,9 +47,13 @@ impl Command for WatchNonBlockCommand {
         });
 
         if let Some(rules) = self.watches.run_on_init() {
-            stdout::info("Running on init commands.");
-            if let Err(err) = worker.schedule(rules, "") {
-                stdout::error(&format!("failed to initiate next run: {:?}", err));
+            if self.run_on_init {
+                stdout::info("Running on init commands.");
+                if let Err(err) = worker.schedule(rules, "") {
+                    stdout::error(&format!("failed to initiate next run: {:?}", err));
+                }
+            } else {
+                stdout::info("Watching...");
             }
         } else {
             stdout::info("Watching...");

--- a/src/environment.rs
+++ b/src/environment.rs
@@ -4,6 +4,8 @@ pub fn is_enabled(name: &str) -> bool {
     value == "1" || value == "true"
 }
 
+// NOTE This is necessary to avoid conflicts with environment variables
+// In the tests/common/macros.rs the variables are set to default
 #[cfg(feature = "test-integration")]
 pub fn is_enabled(name: &str) -> bool {
     let value = std::env::var(format!("_TEST_{}", name)).unwrap_or_else(|_| "0".to_string());

--- a/src/main.rs
+++ b/src/main.rs
@@ -276,13 +276,14 @@ pub fn execute_watch_command(watches: Watches, args: Args) {
     let verbose = args.flag_V;
     let fail_fast = args.flag_fail_fast || environment::is_enabled("FUNZZY_BAIL");
     let fail_fast_env = args.flag_non_block || environment::is_enabled("FUNZZY_NON_BLOCK");
-    // TODO disabled
-    // let run_on_init = !args.flag_no_run_on_init;
+
+    let run_on_init = !args.flag_no_run_on_init;
     if fail_fast_env {
         execute(WatchNonBlockCommand::new(
-            watches, verbose, fail_fast,
-            // TODO disabled
-            // run_on_init,
+            watches,
+            verbose,
+            fail_fast,
+            run_on_init,
         ))
     } else {
         execute(WatchCommand::new(watches, verbose, fail_fast))

--- a/src/main.rs
+++ b/src/main.rs
@@ -55,6 +55,7 @@ Options:
   -t --target <name>      Execute only the given task target (if empty list availables).
   -n --non-block          Execute tasks and cancel them if a new event is received.
   -b --fail-fast          Bail current execution if a task fails (exit code != 0).
+  --no-run-on-init        Do not run tasks on initialization.
   -h --help               Show this message.
   -v --version            Show version.
   -V                      Use verbose output.
@@ -85,6 +86,7 @@ pub struct Args {
     pub flag_V: bool,
 
     pub flag_non_block: bool,
+    pub flag_no_run_on_init: bool,
     pub flag_fail_fast: bool,
 }
 
@@ -274,8 +276,14 @@ pub fn execute_watch_command(watches: Watches, args: Args) {
     let verbose = args.flag_V;
     let fail_fast = args.flag_fail_fast || environment::is_enabled("FUNZZY_BAIL");
     let fail_fast_env = args.flag_non_block || environment::is_enabled("FUNZZY_NON_BLOCK");
+    // TODO disabled
+    // let run_on_init = !args.flag_no_run_on_init;
     if fail_fast_env {
-        execute(WatchNonBlockCommand::new(watches, verbose, fail_fast))
+        execute(WatchNonBlockCommand::new(
+            watches, verbose, fail_fast,
+            // TODO disabled
+            // run_on_init,
+        ))
     } else {
         execute(WatchCommand::new(watches, verbose, fail_fast))
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -286,7 +286,7 @@ pub fn execute_watch_command(watches: Watches, args: Args) {
             run_on_init,
         ))
     } else {
-        execute(WatchCommand::new(watches, verbose, fail_fast))
+        execute(WatchCommand::new(watches, verbose, fail_fast, run_on_init))
     }
 
     let _ = th.join().expect("Failed to join config watcher thread");

--- a/tests/common/lib.rs
+++ b/tests/common/lib.rs
@@ -100,6 +100,7 @@ where
     handler(
         Command::new(bin_path)
             .arg("-c")
+            .env("_TEST_FUNZZY_COLORED", "0")
             .arg(dir.join(opts.example_file))
             .stdout(Stdio::from(output_file)),
         File::open(dir.join(opts.output_file)).expect("failed to open file"),

--- a/tests/tasks_that_run_on_init.rs
+++ b/tests/tasks_that_run_on_init.rs
@@ -19,7 +19,8 @@ fn test_it_executes_tasks_on_init_when_configured() {
                 |fzz_cmd, mut output_log| {
                     let mut child = fzz_cmd
                         .env("_TEST_FUNZZY_COLORED", "1")
-                        .spawn().expect("failed to spawn child");
+                        .spawn()
+                        .expect("failed to spawn child");
 
                     defer!({
                         child.kill().expect("failed to kill child");

--- a/tests/tasks_that_run_on_init.rs
+++ b/tests/tasks_that_run_on_init.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::io::prelude::*;
 
-use pretty_assertions::assert_eq;
+// use pretty_assertions::assert_eq;
 
 #[path = "./common/lib.rs"]
 mod setup;
@@ -17,7 +17,9 @@ fn test_it_executes_tasks_on_init_when_configured() {
                     example_file: "examples/list-of-tasks-run-on-init.yml",
                 },
                 |fzz_cmd, mut output_log| {
-                    let mut child = fzz_cmd.spawn().expect("failed to spawn child");
+                    let mut child = fzz_cmd
+                        .env("_TEST_FUNZZY_COLORED", "1")
+                        .spawn().expect("failed to spawn child");
 
                     defer!({
                         child.kill().expect("failed to kill child");
@@ -56,6 +58,8 @@ Funzzy results ----------------------------
 \u{1b}[32mSuccess\u{1b}[0m; Completed: 3; Failed: 0; Durantion: 0.0000s"
                     );
 
+                    // FIXME: this should not be needed sleep 5s
+                    std::thread::sleep(std::time::Duration::from_secs(5));
                     write_to_file!("examples/workdir/trigger-watcher.txt");
 
                     wait_until!(
@@ -68,6 +72,87 @@ Funzzy results ----------------------------
                         },
                         "OUTPUT: {}",
                         output
+                    );
+                },
+            );
+
+            Ok(())
+        },
+    )
+    .expect("failed to run test");
+}
+
+#[test]
+fn test_it_does_not_executes_tasks_on_init_when_no_run_on_init_flag() {
+    setup::with_env(
+        HashMap::from([("FUNZZY_COLORED".to_string(), "1".to_string())]),
+        || {
+            setup::with_example(
+                setup::Options {
+                    output_file:
+                        "test_it_does_not_executes_tasks_on_init_when_no_run_on_init_flag.log",
+                    example_file: "examples/list-of-tasks-run-on-init.yml",
+                },
+                |fzz_cmd, mut output_log| {
+                    let mut child = fzz_cmd
+                        .arg("--no-run-on-init")
+                        .env("_TEST_FUNZZY_COLORED", "1")
+                        .spawn()
+                        .expect("failed to spawn child");
+
+                    defer!({
+                        child.kill().expect("failed to kill child");
+                    });
+
+                    let mut output = String::new();
+
+                    wait_until!(
+                        {
+                            output_log
+                                .read_to_string(&mut output)
+                                .expect("failed to read from file");
+
+                            !output.contains("Running on init commands")
+                                && output.contains("Watching...")
+                        },
+                        "No task in the example was configured with run_on_init {}",
+                        output
+                    );
+
+                    // FIXME: this should not be needed sleep 5s
+                    std::thread::sleep(std::time::Duration::from_secs(5));
+                    write_to_file!("examples/workdir/trigger-watcher.txt");
+
+                    wait_until!(
+                        {
+                            output_log
+                                .read_to_string(&mut output)
+                                .expect("failed to read from file");
+
+                            output.contains("should not run on init but on change")
+                        },
+                        "OUTPUT: {}",
+                        output
+                    );
+
+                    assert_eq!(
+                        setup::clean_output(&output),
+                        "\u{1b}[34mFunzzy\u{1b}[0m: Watching...
+
+[2J
+\u{1b}[34mFunzzy\u{1b}[0m: echo 'running on init first' 
+
+running on init first
+
+\u{1b}[34mFunzzy\u{1b}[0m: echo \"should not run on init but on change\" 
+
+should not run on init but on change
+
+\u{1b}[34mFunzzy\u{1b}[0m: echo \"run on init sencod\" 
+
+run on init sencod
+Funzzy results ----------------------------
+\u{1b}[32mSuccess\u{1b}[0m; Completed: 3; Failed: 0; Durantion: 0.0000s"
                     );
                 },
             );


### PR DESCRIPTION
This commit introduces a new command-line flag `--no-run-on-init` that allows users to disable the automatic execution of tasks configured with `run_on_init: true` when the watcher starts.

Detailed Changes:
- `docs/FLAG_NO_RUN_INIT.md`: Added documentation explaining the behavior and usage of the new `--no-run-on-init` flag.
- `src/cli/watch.rs`: Updated the `WatchCommand` struct and the `new` method to include the `run_on_init` flag. Modified logic to check the `run_on_init` condition.
- `src/cli/watch_non_block.rs`: Updated the `WatchNonBlockCommand` struct and the `new` method to include the `run_on_init` flag. Altered logic to respect the `run_on_init` condition.
- `src/main.rs`: Modified the `Args` struct to include `flag_no_run_on_init`. Updated `execute_watch_command` to handle the new flag and pass it to the `WatchCommand` or `WatchNonBlockCommand`.
- `tests/tasks_that_run_on_init.rs`: Added a new test `test_it_does_not_executes_tasks_on_init_when_no_run_on_init_flag` to ensure tasks do not run on initialization when the flag is set.

(cherry picked from commit cadb44ae190bcf9251b0b27641297d4d4274c12f)