### PR TITLE
chore(ci): update integration test workflow configuration

### DIFF
--- a/.github/workflows/on-push-integration-test.yml
+++ b/.github/workflows/on-push-integration-test.yml
@@ -16,5 +16,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: Run integration
+        run: make integration
+
       - name: Run integration e2e tests
         run: make integration-e2e

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -24,6 +24,3 @@ jobs:
 
       - name: Run unit tests
         run: make tests
-
-      - name: Run integration
-        run: make integration


### PR DESCRIPTION
Summary:
This commit modifies the GitHub Actions workflow configuration to separate integration test runs into a distinct step in the `on-push-integration-test.yml` and removes it from `on-push.yml`. Detailed Changes:

 - .github/workflows/on-push-integration-test.yml:
   - Added a new step to run integration tests before the e2e tests using `make integration`.
 - .github/workflows/on-push.yml:
   - Removed the integration test step, which was running `make integration`.

(cherry picked from commit 952365d20585078a1c5010302b8b8e4973b4e791)