### PR TITLE
fix(output): correct typo in 'Duration' string

### DIFF
--- a/src/stdout.rs
+++ b/src/stdout.rs
@@ -66,7 +66,8 @@ pub fn verbose(msg: &str, verbose: bool) {
 #[cfg(not(feature = "test-integration"))]
 /// Print the time elapsed in seconds in the format "Finished in 0.1234s"
 pub fn print_time_elapsed(elapsed: std::time::Duration) -> () {
-    print!("Durantion: {:.4}s", elapsed.as_secs_f32());
+    let message = format!("Duration: {:.4}s", elapsed.as_secs_f32());
+    print!("{}", message);
     let res = std::io::stdout().flush();
 
     match res {
@@ -83,7 +84,8 @@ pub fn print_time_elapsed(elapsed: std::time::Duration) -> () {
 /// Print mocked time elapsed always as: "Finished in 0.0s"
 pub fn print_time_elapsed(_: std::time::Duration) -> () {
     let elapsed = std::time::Duration::from_secs(0);
-    print!("Durantion: {:.4}s", elapsed.as_secs_f32());
+    let message = format!("Duration: {:.4}s", elapsed.as_secs_f32());
+    print!("{}", message);
     std::io::stdout().flush().expect("Failed to flush stdout");
 }
 

--- a/tests/tasks_that_run_on_init.rs
+++ b/tests/tasks_that_run_on_init.rs
@@ -56,7 +56,7 @@ run on init sencod
 
 only run on init
 Funzzy results ----------------------------
-\u{1b}[32mSuccess\u{1b}[0m; Completed: 3; Failed: 0; Durantion: 0.0000s"
+\u{1b}[32mSuccess\u{1b}[0m; Completed: 3; Failed: 0; Duration: 0.0000s"
                     );
 
                     // FIXME: this should not be needed sleep 5s
@@ -153,7 +153,7 @@ should not run on init but on change
 
 run on init sencod
 Funzzy results ----------------------------
-\u{1b}[32mSuccess\u{1b}[0m; Completed: 3; Failed: 0; Durantion: 0.0000s"
+\u{1b}[32mSuccess\u{1b}[0m; Completed: 3; Failed: 0; Duration: 0.0000s"
                     );
                 },
             );

--- a/tests/tasks_with_filepath_template.rs
+++ b/tests/tasks_with_filepath_template.rs
@@ -69,7 +69,7 @@ Funzzy: echo '' | sed -r s/trigger/foobar/
 
 
 Funzzy results ----------------------------
-Success; Completed: 3; Failed: 0; Durantion: 0.0000s
+Success; Completed: 3; Failed: 0; Duration: 0.0000s
 [2J
 Funzzy: echo 'this file has changed: $PWD/examples/workdir/trigger-watcher.txt' 
 
@@ -83,7 +83,7 @@ Funzzy: echo '$PWD/examples/workdir/trigger-watcher.txt' | sed -r s/trigger/foob
 
 $PWD/examples/workdir/foobar-watcher.txt
 Funzzy results ----------------------------
-Success; Completed: 3; Failed: 0; Durantion: 0.0000s";
+Success; Completed: 3; Failed: 0; Duration: 0.0000s";
 
             assert_eq!(
                 setup::clean_output(&output),
@@ -161,7 +161,7 @@ Funzzy: echo 'this is invalid: {{ foobar }} (no!)'
 
 this is invalid: {{ foobar }} (no!)
 Funzzy results ----------------------------
-Success; Completed: 4; Failed: 0; Durantion: 0.0000s
+Success; Completed: 4; Failed: 0; Duration: 0.0000s
 [2JFunzzy warning: Unknown template variable 'foobar'.
 
 Funzzy: echo '$PWD/examples/workdir/trigger-watcher.txt' 
@@ -180,7 +180,7 @@ Funzzy: echo 'this is invalid: {{ foobar }} (no!)'
 
 this is invalid: {{ foobar }} (no!)
 Funzzy results ----------------------------
-Success; Completed: 4; Failed: 0; Durantion: 0.0000s";
+Success; Completed: 4; Failed: 0; Duration: 0.0000s";
 
             assert_eq!(
                 setup::clean_output(&output),

--- a/tests/watcher_does_not_die_with_failing_tasks.rs
+++ b/tests/watcher_does_not_die_with_failing_tasks.rs
@@ -56,7 +56,7 @@ Funzzy: echo finally
 finally
 Funzzy results ----------------------------
 - Command cat baz/bar/foo has failed with exit status: 1
-Failure; Completed: 2; Failed: 1; Durantion: 0.0000s
+Failure; Completed: 2; Failed: 1; Duration: 0.0000s
 [2J
 Funzzy: echo complex | sed s/complex/third/g 
 
@@ -90,7 +90,7 @@ Funzzy results ----------------------------
 - Command cat foo/bar/baz has failed with exit status: 1
 - Command exit 125 has failed with exit status: 125
 - Command cat baz/bar/foo has failed with exit status: 1
-Failure; Completed: 4; Failed: 4; Durantion: 0.0000s",
+Failure; Completed: 4; Failed: 4; Duration: 0.0000s",
                 "failed to match {}",
                 output
             );

--- a/tests/watching_configured_rules.rs
+++ b/tests/watching_configured_rules.rs
@@ -134,7 +134,7 @@ Funzzy: echo 'something changed in workdir!'
 
 something changed in workdir!
 Funzzy results ----------------------------
-Success; Completed: 4; Failed: 0; Durantion: 0.0000s"
+Success; Completed: 4; Failed: 0; Duration: 0.0000s"
             );
         },
     );

--- a/tests/watching_filtered_tasks_with_target_flag.rs
+++ b/tests/watching_filtered_tasks_with_target_flag.rs
@@ -69,7 +69,7 @@ Funzzy: echo 'quick lint'
 
 quick lint
 Funzzy results ----------------------------
-Success; Completed: 3; Failed: 0; Durantion: 0.0000s"
+Success; Completed: 3; Failed: 0; Duration: 0.0000s"
             );
         },
     );

--- a/tests/watching_with_fail_fast_flag.rs
+++ b/tests/watching_with_fail_fast_flag.rs
@@ -42,7 +42,7 @@ Funzzy: cat baz/bar/foo
 
 Funzzy results ----------------------------
 - Command cat baz/bar/foo has failed with exit status: 1
-Failure; Completed: 1; Failed: 1; Durantion: 0.0000s"
+Failure; Completed: 1; Failed: 1; Duration: 0.0000s"
             );
 
             write_to_file!("examples/workdir/trigger-watcher.txt");
@@ -67,7 +67,7 @@ Funzzy: cat baz/bar/foo
 
 Funzzy results ----------------------------
 - Command cat baz/bar/foo has failed with exit status: 1
-Failure; Completed: 1; Failed: 1; Durantion: 0.0000s
+Failure; Completed: 1; Failed: 1; Duration: 0.0000s
 [2J
 Funzzy: echo complex | sed s/complex/third/g 
 
@@ -81,7 +81,7 @@ Funzzy: exit 1
 
 Funzzy results ----------------------------
 - Command exit 1 has failed with exit status: 1
-Failure; Completed: 2; Failed: 1; Durantion: 0.0000s",
+Failure; Completed: 2; Failed: 1; Duration: 0.0000s",
                 "failed to match ouput: {}",
                 output
             );
@@ -126,7 +126,7 @@ Funzzy: cat baz/bar/foo
 
 Funzzy results ----------------------------
 - Command cat baz/bar/foo has failed with exit status: 1
-Failure; Completed: 1; Failed: 1; Durantion: 0.0000s"
+Failure; Completed: 1; Failed: 1; Duration: 0.0000s"
                     );
 
                     write_to_file!("examples/workdir/trigger-watcher.txt");
@@ -151,7 +151,7 @@ Funzzy: cat baz/bar/foo
 
 Funzzy results ----------------------------
 - Command cat baz/bar/foo has failed with exit status: 1
-Failure; Completed: 1; Failed: 1; Durantion: 0.0000s
+Failure; Completed: 1; Failed: 1; Duration: 0.0000s
 [2J
 Funzzy: echo complex | sed s/complex/third/g 
 
@@ -165,7 +165,7 @@ Funzzy: exit 1
 
 Funzzy results ----------------------------
 - Command exit 1 has failed with exit status: 1
-Failure; Completed: 2; Failed: 1; Durantion: 0.0000s",
+Failure; Completed: 2; Failed: 1; Duration: 0.0000s",
                         "failed to match ouput: {}",
                         output
                     );
@@ -215,7 +215,7 @@ Funzzy: cat baz/bar/foo
 
 Funzzy results ----------------------------
 - Command cat baz/bar/foo has failed with exit status: 1
-Failure; Completed: 1; Failed: 1; Durantion: 0.0000s"
+Failure; Completed: 1; Failed: 1; Duration: 0.0000s"
             );
 
             write_to_file!("examples/workdir/trigger-watcher.txt");
@@ -240,7 +240,7 @@ Funzzy: cat baz/bar/foo
 
 Funzzy results ----------------------------
 - Command cat baz/bar/foo has failed with exit status: 1
-Failure; Completed: 1; Failed: 1; Durantion: 0.0000s
+Failure; Completed: 1; Failed: 1; Duration: 0.0000s
 [2J
 Funzzy: echo complex | sed s/complex/third/g 
 
@@ -254,7 +254,7 @@ Funzzy: exit 1
 
 Funzzy results ----------------------------
 - Command exit 1 has failed with exit status: 1
-Failure; Completed: 2; Failed: 1; Durantion: 0.0000s",
+Failure; Completed: 2; Failed: 1; Duration: 0.0000s",
                 "failed to match ouput: {}",
                 output
             );


### PR DESCRIPTION
Summary:
Misspelling "Durantion" was corrected to "Duration".

(cherry picked from commit 720168abd55f35bb70900390b4ec9cc0530a98fb)