### PR TITLE
fix(watch): anchor watch patterns to project root

### DIFF
--- a/examples/workdir/backend/test.rs
+++ b/examples/workdir/backend/test.rs
@@ -1,0 +1,1 @@
+test_content

--- a/examples/workdir/frontend/test.js
+++ b/examples/workdir/frontend/test.js
@@ -1,0 +1,1 @@
+test_content

--- a/examples/workdir/regular/test.txt
+++ b/examples/workdir/regular/test.txt
@@ -1,0 +1,1 @@
+test_content


### PR DESCRIPTION
This commit changes how watch patterns are resolved by anchoring them to the project root directory.

Detailed Changes:
 - Implementation:
   - Changed the resolution of watch patterns to be relative to the project root instead of the current working directory.