### PR TITLE
fix(deps): preserve Rust 1.78 test compatibility

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ nix = "0.26.2"
 once_cell = "1.19"
 
 [dev-dependencies]
-assert_cmd = "2.0.14"
+assert_cmd = "=2.1.2"
 predicates = "3.1.0"
 pretty_assertions = "1.4.1"
 


### PR DESCRIPTION
## Problem

The semver range for `assert_cmd` allows Cargo to select 2.2.2, whose edition-2024 manifest cannot be parsed by the repository default Rust 1.78 toolchain.

## Change

Pin `assert_cmd` to 2.1.2, the version already recorded in `Cargo.lock`, so dependency resolution remains compatible and deterministic.

## Verification

- `make lint`
- `cargo test` using the repository default Rust 1.78 toolchain