### PR TITLE
fix: merge root `on` rules into tasks instead of overriding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,9 @@ tests/integration/workdir/
 *.log
 tests/integration/release/
 
+# Agent tooling caches (e.g. AST index)
+.pi/
+
 # Nix stuff
 result
 .beads

--- a/.watch.yaml
+++ b/.watch.yaml
@@ -14,6 +14,12 @@
 #
 on:
   socket: .tmp/funzzy/control.sock
+  change:
+    - "src/**"
+    - "tests/**"
+  ignore:
+    - "src/**/*log*"
+    - '.pi/'
 
 tasks:
   - name: start by updating deps @quick
@@ -30,11 +36,7 @@ tasks:
       - cargo fmt -- --check {{filepath}}
       - cargo fmt
     run_on_init: true
-    change:
-      - "src/**"
-      - "tests/**"
     ignore:
-      - "src/**/*log*"
       - "examples/*.yml"
       - "examples/*.yaml"
       - "examples/workdir/**"
@@ -44,9 +46,6 @@ tasks:
      cat .github/workflows/on-push.yml \
       | yq '.jobs | .[] | .steps | .[] | .run | select(. != null)' \
       | xargs -I {} bash -c {}
-    change:
-      - "src/**"
-      - "tests/**/*.rs"
     run_on_init: true
 
     # Moved integration to earlier because it is faster than @nixbuild
@@ -61,13 +60,9 @@ tasks:
       # if fails open nvim with the failing logs
       - "cargo test --features test-integration --test ${INTEGRATION_TEST:-'*'} -- --nocapture"
       - rm -rf /tmp/fzz
-    change:
-      - "src/**"
-      - "tests/**/*.rs"
     ignore:
       - "examples/reload-config-example.yml"
       - "examples/workdir/**"
-      - "**/*.log"
     run_on_init: true
 
   - name: nix checks @nixbuild
@@ -100,7 +95,6 @@ tasks:
       - "**/*.nix"
     run_on_init: true
     ignore:
-      - "**/*.log"
       - "**/*.txt"
 
   - name: after all checks if no error stage to git @quick @nixbuild

--- a/.watch.yaml
+++ b/.watch.yaml
@@ -19,7 +19,7 @@ on:
     - "tests/**"
   ignore:
     - "src/**/*log*"
-    - '.pi/'
+    - "**/.pi/**"
 
 tasks:
   - name: start by updating deps @quick
@@ -40,6 +40,7 @@ tasks:
       - "examples/*.yml"
       - "examples/*.yaml"
       - "examples/workdir/**"
+      - "**/.pi/**"
 
   - name: run my test @quick @agent-final
     run: |
@@ -63,6 +64,7 @@ tasks:
     ignore:
       - "examples/reload-config-example.yml"
       - "examples/workdir/**"
+      - "**/.pi/**"
     run_on_init: true
 
   - name: nix checks @nixbuild
@@ -96,6 +98,7 @@ tasks:
     run_on_init: true
     ignore:
       - "**/*.txt"
+      - "**/.pi/**"
 
   - name: after all checks if no error stage to git @quick @nixbuild
     run:
@@ -111,6 +114,7 @@ tasks:
     ignore:
       - "examples/workdir/**"
       - "examples/reload-config-example.yml"
+      - "**/.pi/**"
     run_on_init: true
 
   - name: install locally @quick

--- a/.watch.yaml
+++ b/.watch.yaml
@@ -40,7 +40,6 @@ tasks:
       - "examples/*.yml"
       - "examples/*.yaml"
       - "examples/workdir/**"
-      - "**/.pi/**"
 
   - name: run my test @quick @agent-final
     run: |
@@ -64,7 +63,6 @@ tasks:
     ignore:
       - "examples/reload-config-example.yml"
       - "examples/workdir/**"
-      - "**/.pi/**"
     run_on_init: true
 
   - name: nix checks @nixbuild
@@ -98,7 +96,6 @@ tasks:
     run_on_init: true
     ignore:
       - "**/*.txt"
-      - "**/.pi/**"
 
   - name: after all checks if no error stage to git @quick @nixbuild
     run:
@@ -114,7 +111,6 @@ tasks:
     ignore:
       - "examples/workdir/**"
       - "examples/reload-config-example.yml"
-      - "**/.pi/**"
     run_on_init: true
 
   - name: install locally @quick

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -79,12 +79,12 @@ tasks:
   - name: build
     run: cargo build
 
-  # This task overrides the 'change' pattern but inherits 'ignore'
+  # This task extends the common 'change' patterns
   - name: test
     run: cargo test
     change: "tests/**"
 
-  # This task overrides both 'change' and 'ignore'
+  # This task extends both 'change' and 'ignore'
   - name: lint
     run: cargo clippy
     change: "src/**/*.rs"
@@ -94,8 +94,8 @@ tasks:
 **Key Points:**
 - **Backward Compatible**: The classic array format still works perfectly
 - **Optional `on` Section**: You can omit it if you don't need common rules
-- **Override Semantics**: Task-specific patterns completely replace common ones (not merged)
-- **Flexible**: Each task can inherit, override, or ignore common rules
+- **Merge Semantics**: Task-specific patterns are merged with (added to) the common ones, so root-level scope and safety rails always apply
+- **Flexible**: Each task inherits the common rules and can extend them
 
 See [examples/common-rules.yml](../examples/common-rules.yml) for a complete example.
 
@@ -146,7 +146,7 @@ When you have distinct areas of your project that watch different files (e.g., f
 
 **Key Points:**
 - Each group is isolated - changes in one group don't affect others
-- Tasks within a group can still override group-level `change` and `ignore` patterns
+- Tasks within a group extend the group-level `change` and `ignore` patterns
 - You can mix groups and regular tasks in the same configuration
 - Full backward compatibility maintained
 

--- a/examples/common-rules.yml
+++ b/examples/common-rules.yml
@@ -6,12 +6,12 @@
 # Benefits:
 # - Reduces duplication of watch patterns
 # - Makes configuration more maintainable
-# - Individual tasks can still override common rules
+# - Individual tasks extend the common rules
 #
 # Note: For organizing tasks into multiple groups with different common rules,
 # see examples/nested-groups.yml
 
-# Common rules shared by all tasks (unless overridden)
+# Common rules shared by all tasks
 on:
   change:
     - "src/**"
@@ -21,7 +21,7 @@ on:
     - "**/*.tmp"
     - "**/node_modules/"
 
-# Individual tasks that inherit or override common rules
+# Individual tasks inherit and extend the common rules
 tasks:
   # This task inherits all common rules
   - name: build
@@ -32,12 +32,12 @@ tasks:
     run: cargo check
     run_on_init: true
 
-  # This task overrides the 'change' pattern but inherits 'ignore'
+  # This task extends the common 'change' patterns
   - name: test
     run: cargo test
     change: "tests/**"
 
-  # This task overrides both 'change' and 'ignore'
+  # This task extends both 'change' and 'ignore'
   - name: lint
     run: cargo clippy
     change: "src/**/*.rs"

--- a/examples/nested-groups.yml
+++ b/examples/nested-groups.yml
@@ -8,7 +8,7 @@
 # - Each group can watch different file patterns
 # - Reduces duplication within each group
 # - Better separation of concerns
-# - Individual tasks can still override group-level rules
+# - Individual tasks extend the group-level rules
 #
 # Use this format when:
 # - You have distinct areas of your project that watch different files
@@ -40,7 +40,7 @@
       run: npm run typecheck
       run_on_init: true
 
-    # This task overrides the watch pattern to only watch specific files
+    # This task extends the group watch patterns with additional files
     - name: frontend-lint-styles
       run: npm run lint:css
       change: "src/**/*.css"
@@ -66,7 +66,7 @@
     - name: backend-clippy
       run: cargo clippy
 
-    # This task overrides the change pattern to watch only Rust files
+    # This task extends the group change patterns with Rust files
     - name: backend-format-check
       run: cargo fmt -- --check
       change: "src/**/*.rs"

--- a/src/rules.rs
+++ b/src/rules.rs
@@ -459,27 +459,16 @@ fn rule_from_with_common(yaml: &Yaml, common: &CommonRules) -> errors::Result<Ru
     let name = yaml::extract_string(yaml, "name")?;
     let commands = yaml::extract_list(yaml, "run")?;
 
-    // Extract task-specific patterns, or use common rules if not specified
-    let watch_patterns_str = match yaml::extract_list(yaml, "change") {
-        Ok(patterns) => patterns,
-        Err(_) => {
-            // Task doesn't define 'change', inherit from common rules
-            common.change.clone()
-        }
-    };
+    // Tasks EXTEND the shared `on` rules; they never replace them. A task's
+    // own `change` and `ignore` are appended to (and deduped against) the
+    // common patterns, so root-level scope and safety rails always apply.
+    let task_change = yaml::extract_list(yaml, "change").unwrap_or_default();
+    let task_ignore = yaml::extract_list(yaml, "ignore").unwrap_or_default();
 
-    let ignore_patterns_str = match yaml::extract_list(yaml, "ignore") {
-        Ok(patterns) => patterns,
-        Err(_) => {
-            // Task doesn't define 'ignore', inherit from common rules
-            common.ignore.clone()
-        }
-    };
+    let watch_patterns = ensure_glob_only(merge_patterns(&common.change, task_change), "change")?;
+    let ignore_patterns = ensure_glob_only(merge_patterns(&common.ignore, task_ignore), "ignore")?;
 
     let run_on_init = yaml::extract_bool(yaml, "run_on_init");
-
-    let watch_patterns = ensure_glob_only(watch_patterns_str, "change")?;
-    let ignore_patterns = ensure_glob_only(ignore_patterns_str, "ignore")?;
 
     Ok(Rules {
         name,
@@ -489,6 +478,18 @@ fn rule_from_with_common(yaml: &Yaml, common: &CommonRules) -> errors::Result<Ru
         run_on_init,
         yaml: Some(yaml.clone()),
     })
+}
+
+/// Append task-specific patterns to the common ones, dropping duplicates.
+/// Common patterns keep their position so merged output stays stable.
+fn merge_patterns(common: &[String], task: Vec<String>) -> Vec<String> {
+    let mut merged: Vec<String> = common.to_vec();
+    for pattern in task {
+        if !merged.contains(&pattern) {
+            merged.push(pattern);
+        }
+    }
+    merged
 }
 
 fn ensure_glob_only(patterns: Vec<String>, field_name: &str) -> errors::Result<Vec<String>> {
@@ -1292,7 +1293,7 @@ tasks:
     }
 
     #[test]
-    fn it_allows_tasks_to_override_common_change() {
+    fn it_merges_common_change_with_task_change() {
         let file_content = "
 on:
   change:
@@ -1312,17 +1313,17 @@ tasks:
         let rules = from_yaml(file_content).expect("Failed to parse yaml");
         assert_eq!(rules.len(), 2);
 
-        // First task inherits common change
+        // First task has only the common patterns
         assert_eq!(rules[0].watch_patterns(), vec!["src/**"]);
         assert_eq!(rules[0].ignore_glob_patterns(), vec!["**/*.log"]);
 
-        // Second task overrides change but inherits ignore
-        assert_eq!(rules[1].watch_patterns(), vec!["tests/**"]);
+        // Second task EXTENDS common change; root scope always applies
+        assert_eq!(rules[1].watch_patterns(), vec!["src/**", "tests/**"]);
         assert_eq!(rules[1].ignore_glob_patterns(), vec!["**/*.log"]);
     }
 
     #[test]
-    fn it_allows_tasks_to_override_common_ignore() {
+    fn it_merges_common_ignore_with_task_ignore() {
         let file_content = "
 on:
   change:
@@ -1341,11 +1342,40 @@ tasks:
         let rules = from_yaml(file_content).expect("Failed to parse yaml");
         assert_eq!(rules.len(), 1);
 
-        // Task overrides ignore but inherits change
+        // Task extends common ignore; root safety rails always apply
         assert_eq!(rules[0].watch_patterns(), vec!["src/**"]);
         assert_eq!(
             rules[0].ignore_glob_patterns(),
-            vec!["**/*.tmp", "target/**"]
+            vec!["**/*.log", "**/*.tmp", "target/**"]
+        );
+    }
+
+    #[test]
+    fn it_dedupes_common_and_task_patterns() {
+        let file_content = "
+on:
+  change:
+    - 'src/**'
+  ignore:
+    - '**/*.log'
+
+tasks:
+  - name: build
+    run: 'cargo build'
+    change:
+      - 'src/**'
+      - 'tests/**'
+    ignore:
+      - '**/*.log'
+      - '**/*.tmp'
+        ";
+
+        let rules = from_yaml(file_content).expect("Failed to parse yaml");
+        assert_eq!(rules.len(), 1);
+        assert_eq!(rules[0].watch_patterns(), vec!["src/**", "tests/**"]);
+        assert_eq!(
+            rules[0].ignore_glob_patterns(),
+            vec!["**/*.log", "**/*.tmp"]
         );
     }
 
@@ -1674,7 +1704,7 @@ tasks:
     }
 
     #[test]
-    fn it_allows_task_overrides_in_nested_group() {
+    fn it_merges_common_rules_in_nested_group() {
         let file_content = "
         - on:
             change: 'src/**'
@@ -1683,34 +1713,34 @@ tasks:
             - name: inherits-all
               run: echo 'inherit'
 
-            - name: overrides-change
-              run: echo 'override'
+            - name: extends-change
+              run: echo 'extend'
               change: 'custom/**'
 
-            - name: overrides-ignore
-              run: echo 'override'
+            - name: extends-ignore
+              run: echo 'extend'
               ignore: '**/*.tmp'
         ";
 
         let rules = from_yaml(file_content).expect("Failed to parse yaml");
         assert_eq!(rules.len(), 3);
 
-        // First task inherits common rules
+        // First task has only the common rules
         assert_eq!(rules[0].name, "inherits-all");
         assert!(rules[0].watch_patterns().contains(&"src/**".to_string()));
         assert!(rules[0].ignore_patterns.contains(&"**/*.log".to_string()));
 
-        // Second task overrides change
-        assert_eq!(rules[1].name, "overrides-change");
+        // Second task extends change; common scope always applies
+        assert_eq!(rules[1].name, "extends-change");
         assert!(rules[1].watch_patterns().contains(&"custom/**".to_string()));
-        assert!(!rules[1].watch_patterns().contains(&"src/**".to_string()));
+        assert!(rules[1].watch_patterns().contains(&"src/**".to_string()));
         assert!(rules[1].ignore_patterns.contains(&"**/*.log".to_string()));
 
-        // Third task overrides ignore
-        assert_eq!(rules[2].name, "overrides-ignore");
+        // Third task extends ignore; common safety rails always apply
+        assert_eq!(rules[2].name, "extends-ignore");
         assert!(rules[2].watch_patterns().contains(&"src/**".to_string()));
         assert!(rules[2].ignore_patterns.contains(&"**/*.tmp".to_string()));
-        assert!(!rules[2].ignore_patterns.contains(&"**/*.log".to_string()));
+        assert!(rules[2].ignore_patterns.contains(&"**/*.log".to_string()));
     }
 
     #[test]

--- a/src/watches.rs
+++ b/src/watches.rs
@@ -354,6 +354,43 @@ mod tests {
     }
 
     #[test]
+    fn it_ignores_nested_tooling_cache_dirs() {
+        // Regression: tooling (e.g. agent AST indexers) writes cache files under
+        // watched dirs like tests/.pi/ast-index.sqlite. A task with its own
+        // `ignore` block must be able to exclude nested `.pi` dirs using a
+        // `**/.pi/**` glob, otherwise non-Rust files reach `cargo fmt`.
+        let file_content = "
+            - name: lint
+              run: 'cargo fmt'
+              change: 'tests/**'
+              ignore: '**/.pi/**'
+        ";
+        let watches = Watches::new(rules::from_yaml(&file_content).expect("Error parsing yaml"));
+        assert!(watches.watch("tests/foo.rs").is_some());
+        assert!(watches.watch("tests/.pi/ast-index.sqlite").is_none());
+    }
+
+    #[test]
+    fn it_ignores_tooling_cache_in_real_watch_config() {
+        // End-to-end guard against the real .watch.yaml: the lint task has its
+        // own `ignore` (which overrides `on.ignore`), so it must list `**/.pi/**`
+        // explicitly to keep agent cache files away from `cargo fmt`.
+        let here = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
+        let config =
+            std::fs::read_to_string(here.join(".watch.yaml")).expect("missing .watch.yaml");
+        let watches = Watches::new(rules::from_yaml(&config).expect("Error parsing yaml"));
+        let matched: Vec<String> = watches
+            .watch("tests/.pi/ast-index.sqlite")
+            .map(|rules| rules.into_iter().map(|r| r.name).collect())
+            .unwrap_or_default();
+        assert!(
+            matched.is_empty(),
+            "tooling cache must not trigger any task, got: {:?}",
+            matched
+        );
+    }
+
+    #[test]
     fn it_returns_on_init_rules() {
         let file_content = "
             - name: my source


### PR DESCRIPTION
## Problem

A task that defines its own `change` or `ignore` silently **replaces** the root `on.change` / `on.ignore`. This means a root-level safety rail like `on.ignore: [**/.pi/**]` (to keep agent tooling cache files away from `cargo fmt`) is silently dropped for any task that defines its own `ignore`.

## Fix

Tasks now **extend** the root `on` rules instead of replacing them. Task-specific patterns are appended to (and deduped against) the root `on.change` and `on.ignore`, so root scope and safety rails always apply.

```rust
// Before: task change REPLACES root change
change: ["tests/**"] → watches only tests/**

// After: task change EXTENDS root change
change: ["tests/**"] → watches src/** + lib/** + tests/**
```

- `rule_from_with_common` merges common + task patterns (common first, dedup)
- Also merges inside nested groups (`{ on, tasks }` within a list)

## Behavior change

Tasks that define their own `change` or `ignore` now also include the root patterns. Previously they only had their own. This is the intended fix — root patterns are common rules meant to apply everywhere.

## Changes

- `src/rules.rs` — merge logic + `merge_patterns` helper
- `src/watches.rs` — regression tests (config-level + end-to-end against real `.watch.yaml`)
- `.watch.yaml` — `on.ignore: **/.pi/**` (global; cascades to all tasks now)
- `.gitignore` — add `.pi/`
- `docs/USAGE.md`, examples — document merge semantics (was "override")

## Verification

- `cargo test --lib`: 71 passed
- `cargo fmt -- --check`: clean