### PR TITLE
chore(rust): eliminate compiler warnings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,4 +63,4 @@ path = "src/main.rs"
 # alias
 [[bin]]
 name = "fzz"
-path = "src/main.rs"
+path = "src/fzz.rs"

--- a/src/app.rs
+++ b/src/app.rs
@@ -15,10 +15,7 @@ use crate::watches::Watches;
 use crate::{config, diagnostics, environment, logging, rules, stdout, watcher};
 use std::path::PathBuf;
 
-use nix::{
-    sys::signal::{self, Signal},
-    unistd::Pid,
-};
+use nix::sys::signal::Signal;
 use std::io::prelude::*;
 use std::io::{self, IsTerminal};
 use std::process;
@@ -86,7 +83,6 @@ pub fn run() {
         Action::Check => check_config(&args.config),
         Action::Completions { shell } => {
             let mut cmd = crate::arguments::command();
-            use clap::CommandFactory;
             let name = cmd.get_name().to_string();
             let generator = match shell.as_str() {
                 "bash" => clap_complete::Shell::Bash,

--- a/src/arguments.rs
+++ b/src/arguments.rs
@@ -292,15 +292,6 @@ impl Arguments {
         })
     }
 
-    /// Rendered help text for the configured command (used by app fallbacks).
-    fn parse_config_format(raw: Option<&str>) -> OutputFormat {
-        match raw.unwrap_or("human") {
-            "toon" => OutputFormat::Toon,
-            "json" => OutputFormat::Json,
-            _ => OutputFormat::Human,
-        }
-    }
-
     pub fn help_text() -> String {
         command().render_help().to_string()
     }
@@ -1726,7 +1717,7 @@ mod tests {
 #[cfg(test)]
 mod format_tests {
     use super::tests::parse;
-    use super::{Action, Arguments};
+    use super::Action;
     use crate::cli::{ControlAction, OutputFormat};
 
     #[test]
@@ -1773,8 +1764,8 @@ mod format_tests {
 #[cfg(test)]
 mod config_command_tests {
     use super::tests::parse;
-    use super::{Action, Arguments};
-    use crate::cli::{ControlAction, OutputFormat};
+    use super::Action;
+    use crate::cli::OutputFormat;
 
     #[test]
     fn config_schema_parses_with_optional_section() {
@@ -1822,7 +1813,7 @@ mod config_command_tests {
 #[cfg(test)]
 mod completions_tests {
     use super::tests::parse;
-    use super::{Action, Arguments};
+    use super::Action;
 
     #[test]
     fn completions_parses_shell_and_rejects_unknown() {

--- a/src/awaiting.rs
+++ b/src/awaiting.rs
@@ -685,7 +685,6 @@ mod tests {
     #[test]
     fn history_is_bounded_and_evicts_oldest_first() {
         let coordinator = Arc::new(AwaitCoordinator::new());
-        let state = Arc::new(Mutex::new(ControlState::default()));
         for generation in 1..=300 {
             coordinator.observe(&started(generation, None));
             coordinator.observe(&finished(generation, false));

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -335,7 +335,8 @@ mod tests {
     }
 }
 
-/// Returns a full section document (used by tests and the command).
+/// Returns a full section document used by focused schema tests.
+#[cfg(test)]
 fn schema_document(section: &str) -> Value {
     let full = full_schema();
     let body = full["$defs"][section].clone();

--- a/src/config.rs
+++ b/src/config.rs
@@ -768,8 +768,6 @@ pub fn format_rules(rule: &Vec<Rules>) -> String {
 mod tests {
     extern crate yaml_rust;
 
-    use crate::config::OutputPolicy;
-
     use self::yaml_rust::YamlLoader;
     use super::concurrency_from_yaml;
     use super::control_socket_from_yaml;
@@ -2268,6 +2266,7 @@ mod service_tests {
     }
 }
 
+#[cfg(test)]
 mod catalog_allowlist_tests {
     use super::*;
 

--- a/src/duration_recorder.rs
+++ b/src/duration_recorder.rs
@@ -379,7 +379,6 @@ mod tests {
     #[test]
     fn estimate_at_start_is_frozen_and_survives_terminal() {
         let (recorder, _temp) = recorder();
-        let signature = sig(1);
         // Two prior samples -> a measured estimate exists at run start.
         recorder.observe(&started(1, Some("build"), Some(1)));
         recorder.observe(&finished(1, false, None));

--- a/src/duration_store.rs
+++ b/src/duration_store.rs
@@ -556,8 +556,6 @@ mod tests {
 
     #[test]
     fn oversized_profile_snapshot_is_rejected_on_load() {
-        let temp = TempDir::new();
-        let path = temp.0.join("run-durations-v1.json");
         let snapshots = vec![ProfileSnapshot {
             signature: sig(1),
             successes: vec![0; SUCCESS_RETENTION + 1],

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -881,7 +881,6 @@ impl Executor {
     }
 
     fn record_task_outcome(&self, run: &mut Run, task: ActiveTask) {
-        let task_failed = !task.failures.is_empty();
         self.reveal_on_failure(&task, &task.failures);
         if let (Some(outputs), Some(capture)) = (&self.outputs, &task.capture) {
             outputs.record(

--- a/src/fzz.rs
+++ b/src/fzz.rs
@@ -1,0 +1,5 @@
+//! Thin process adapter for the `fzz` binary alias.
+
+fn main() {
+    funzzy::app::run();
+}

--- a/src/snapshot.rs
+++ b/src/snapshot.rs
@@ -289,7 +289,6 @@ mod tests {
     use super::*;
     use crate::awaiting::AwaitCoordinator;
     use crate::executor::Event;
-    use crate::identity::Batch;
     use std::time::Duration;
 
     fn broker() -> (

--- a/src/watch_loop.rs
+++ b/src/watch_loop.rs
@@ -1065,7 +1065,6 @@ mod tests {
     fn it_marks_pending_debounce_through_the_coordinator() {
         use crate::awaiting::AwaitCoordinator;
         use crate::identity::Batch;
-        use crate::output::OutputRegistry;
 
         let watches = Watches::new(vec![rule("my tests")]);
         let worker = Arc::new(workers::Worker::new(false, false, |_| {}));

--- a/src/watcher.rs
+++ b/src/watcher.rs
@@ -345,7 +345,7 @@ fn apply_root_swap(
     current_roots: &mut Vec<String>,
     swap: RootSwap,
 ) {
-    use notify_debouncer_mini::notify::{RecursiveMode, Watcher};
+    use notify_debouncer_mini::notify::RecursiveMode;
     for root in current_roots.iter() {
         if !swap.roots.contains(root) {
             let _ = watcher.unwatch(Path::new(root));

--- a/tests/cli_arguments.rs
+++ b/tests/cli_arguments.rs
@@ -573,7 +573,7 @@ fn spawn_with_config(extra_args: &[&str], log_name: &str) -> (Child, String) {
     let log_path = std::path::Path::new(&log_name);
     let _ = std::fs::remove_file(log_path);
     let log = std::fs::File::create(log_path).expect("failed to create log file");
-    let mut child = StdCommand::new(env!("CARGO_BIN_EXE_fzz"))
+    let child = StdCommand::new(env!("CARGO_BIN_EXE_fzz"))
         .arg("-c")
         .arg(FILTER_EXAMPLE)
         .args(extra_args)
@@ -587,17 +587,15 @@ fn spawn_with_config(extra_args: &[&str], log_name: &str) -> (Child, String) {
 
 #[cfg(feature = "test-integration")]
 fn wait_for_output(log_name: &str, needle: &str) -> String {
-    let mut output = String::new();
-    wait_until!(
-        {
-            output = std::fs::read_to_string(log_name).unwrap_or_default();
-            output.contains(needle)
-        },
-        "fzz output never contained {:?}: {}",
-        needle,
-        output
-    );
-    output
+    for _ in 0..100 {
+        let output = std::fs::read_to_string(log_name).unwrap_or_default();
+        if output.contains(needle) {
+            return output;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(250));
+    }
+    let output = std::fs::read_to_string(log_name).unwrap_or_default();
+    panic!("fzz output never contained {needle:?}: {output}");
 }
 
 #[cfg(feature = "test-integration")]

--- a/tests/command_init_proof.rs
+++ b/tests/command_init_proof.rs
@@ -6,9 +6,12 @@
 //! alternatives fail deterministically. Example profiles never inherit the
 //! human-commented init output.
 
-use std::io::prelude::*;
+#[cfg(feature = "test-integration")]
+use std::io::{Read, Write};
 use std::path::{Path, PathBuf};
-use std::process::{Command, Stdio};
+use std::process::Command;
+#[cfg(feature = "test-integration")]
+use std::process::Stdio;
 
 #[path = "./common/lib.rs"]
 mod setup;

--- a/tests/common/lib.rs
+++ b/tests/common/lib.rs
@@ -117,7 +117,7 @@ where
 
 #[cfg(not(feature = "test-integration"))]
 #[allow(dead_code)]
-pub fn with_output<F>(output_file_path: &str, handler: F) -> ()
+pub fn with_output<F>(_output_file_path: &str, _handler: F) -> ()
 where
     F: FnOnce(&mut Command, File, &std::path::Path) -> (),
 {

--- a/tests/config_reload_invalid.rs
+++ b/tests/config_reload_invalid.rs
@@ -2,7 +2,6 @@
 //! terminal error — never a silent stale continuation, never an abrupt
 //! self-SIGTERM that skips cleanup.
 
-use std::io::prelude::*;
 use std::time::Duration;
 
 #[path = "./common/lib.rs"]
@@ -42,7 +41,7 @@ fn invalid_config_replacement_is_fatal_with_nonzero_exit() {
             .unwrap();
 
         // Wait for the watcher to be up.
-        let mut deadline = std::time::Instant::now() + Duration::from_secs(20);
+        let deadline = std::time::Instant::now() + Duration::from_secs(20);
         loop {
             if let Ok(log) = std::fs::read_to_string(scratch.join("child.out")) {
                 if log.contains("Watching...") {
@@ -60,7 +59,7 @@ fn invalid_config_replacement_is_fatal_with_nonzero_exit() {
         std::fs::write(scratch.join(".watch.yaml"), "jobs: [unclosed").unwrap();
 
         // The watcher must exit nonzero with a terminal config error.
-        let mut deadline = std::time::Instant::now() + Duration::from_secs(20);
+        let deadline = std::time::Instant::now() + Duration::from_secs(20);
         let exit = loop {
             if let Some(status) = child.try_wait().expect("try_wait") {
                 break status;
@@ -120,7 +119,7 @@ fn valid_reload_adds_new_root_and_observes_files_after_commit() {
             .unwrap();
 
         // Wait for the control socket (the watcher is up and subscribing).
-        let mut deadline = std::time::Instant::now() + Duration::from_secs(20);
+        let deadline = std::time::Instant::now() + Duration::from_secs(20);
         let socket = scratch.join("sock");
         loop {
             if std::os::unix::net::UnixStream::connect(&socket).is_ok() {
@@ -141,7 +140,7 @@ fn valid_reload_adds_new_root_and_observes_files_after_commit() {
         .unwrap();
 
         // Wait for the hot-reload message.
-        let mut deadline = std::time::Instant::now() + Duration::from_secs(20);
+        let deadline = std::time::Instant::now() + Duration::from_secs(20);
         loop {
             if let Ok(log) = std::fs::read_to_string(scratch.join("child.out")) {
                 if log.contains("hot-reloading to revision 2") {
@@ -162,7 +161,7 @@ fn valid_reload_adds_new_root_and_observes_files_after_commit() {
         // Create a file in the NEW root AFTER the commit boundary: the docs
         // job must run.
         std::fs::write(scratch.join("docs/guide.md"), "content").unwrap();
-        let mut deadline = std::time::Instant::now() + Duration::from_secs(15);
+        let deadline = std::time::Instant::now() + Duration::from_secs(15);
         let mut ran = false;
         while std::time::Instant::now() < deadline {
             if scratch.join("docs-verdict.txt").exists() {

--- a/tests/config_reload_lifecycle.rs
+++ b/tests/config_reload_lifecycle.rs
@@ -133,7 +133,7 @@ fn result(response: serde_json::Value) -> serde_json::Value {
 }
 
 fn wait_until<F: FnMut() -> bool>(mut condition: F, what: &str) {
-    let mut deadline = std::time::Instant::now() + Duration::from_secs(25);
+    let deadline = std::time::Instant::now() + Duration::from_secs(25);
     while std::time::Instant::now() < deadline {
         if condition() {
             return;

--- a/tests/config_reload_matrix.rs
+++ b/tests/config_reload_matrix.rs
@@ -4,7 +4,6 @@
 //! (or the new behavior appears) — never a process exit, never a silent
 //! stale continuation.
 
-use std::io::prelude::*;
 use std::time::Duration;
 
 #[path = "./common/lib.rs"]
@@ -35,7 +34,7 @@ fn spawn_watcher(scratch: &std::path::Path, config: &str) -> std::process::Child
         .stderr(std::process::Stdio::from(error_log))
         .spawn()
         .unwrap();
-    let mut deadline = std::time::Instant::now() + Duration::from_secs(20);
+    let deadline = std::time::Instant::now() + Duration::from_secs(20);
     loop {
         if let Ok(log) = std::fs::read_to_string(scratch.join("child.out")) {
             if log.contains("Watching...") {
@@ -53,7 +52,7 @@ fn spawn_watcher(scratch: &std::path::Path, config: &str) -> std::process::Child
 
 /// Waits for `needle` in the child log; panics with the log on timeout.
 fn wait_for_log(scratch: &std::path::Path, needle: &str) -> String {
-    let mut deadline = std::time::Instant::now() + Duration::from_secs(20);
+    let deadline = std::time::Instant::now() + Duration::from_secs(20);
     loop {
         if let Ok(log) = std::fs::read_to_string(scratch.join("child.out")) {
             if log.contains(needle) {
@@ -77,7 +76,7 @@ fn base_config() -> String {
 /// non-block watcher used across the matrix).
 fn wait_for_socket(scratch: &std::path::Path) {
     let socket = scratch.join("sock");
-    let mut deadline = std::time::Instant::now() + Duration::from_secs(20);
+    let deadline = std::time::Instant::now() + Duration::from_secs(20);
     loop {
         if std::os::unix::net::UnixStream::connect(&socket).is_ok() {
             break;
@@ -145,7 +144,7 @@ fn root_remove_stops_routing_after_commit() {
 
         // Docs must no longer route after the boundary.
         std::fs::write(scratch.join("docs/old.md"), "x").unwrap();
-        let mut deadline = std::time::Instant::now() + Duration::from_secs(5);
+        let deadline = std::time::Instant::now() + Duration::from_secs(5);
         while std::time::Instant::now() < deadline {
             assert!(
                 !scratch.join("docs-verdict.txt").exists(),
@@ -156,7 +155,7 @@ fn root_remove_stops_routing_after_commit() {
 
         // src still routes under the new revision.
         std::fs::write(scratch.join("src/main.rs"), "x").unwrap();
-        let mut deadline = std::time::Instant::now() + Duration::from_secs(15);
+        let deadline = std::time::Instant::now() + Duration::from_secs(15);
         let mut ran = false;
         while std::time::Instant::now() < deadline {
             if scratch.join("src-verdict.txt").exists() {
@@ -194,14 +193,12 @@ fn overlapping_roots_normalize_to_one_generation() {
 
         // Write in the overlap path: must route exactly once.
         std::fs::write(scratch.join("src/main.rs"), "x").unwrap();
-        let mut deadline = std::time::Instant::now() + Duration::from_secs(15);
-        let mut lines = 0;
+        let deadline = std::time::Instant::now() + Duration::from_secs(15);
         while std::time::Instant::now() < deadline {
-            if let Ok(contents) = std::fs::read_to_string(scratch.join("count.txt")) {
-                lines = contents.lines().count();
-                if lines >= 1 {
-                    break;
-                }
+            if std::fs::read_to_string(scratch.join("count.txt"))
+                .is_ok_and(|contents| contents.lines().next().is_some())
+            {
+                break;
             }
             std::thread::sleep(Duration::from_millis(100));
         }
@@ -240,7 +237,7 @@ fn job_rename_swaps_matching_without_process_exit() {
         );
 
         std::fs::write(scratch.join("src/main.rs"), "x").unwrap();
-        let mut deadline = std::time::Instant::now() + Duration::from_secs(15);
+        let deadline = std::time::Instant::now() + Duration::from_secs(15);
         let mut ran = false;
         while std::time::Instant::now() < deadline {
             if scratch.join("src-v2-verdict.txt").exists() {
@@ -277,7 +274,7 @@ fn ignore_rule_added_on_reload_stops_routing_ignored_path() {
         let _ = std::fs::remove_file(scratch.join("src-verdict.txt"));
 
         std::fs::write(scratch.join("src/ignored/x.rs"), "x").unwrap();
-        let mut deadline = std::time::Instant::now() + Duration::from_secs(5);
+        let deadline = std::time::Instant::now() + Duration::from_secs(5);
         while std::time::Instant::now() < deadline {
             assert!(
                 !scratch.join("src-verdict.txt").exists(),
@@ -309,7 +306,7 @@ fn active_finite_task_survives_config_save() {
         // sleep races the 1s debounce window: under parallel load the batch
         // can fire after the reload commit and route the fast job instead,
         // which would never produce the slow verdict.
-        let mut deadline = std::time::Instant::now() + Duration::from_secs(15);
+        let deadline = std::time::Instant::now() + Duration::from_secs(15);
         let mut slow_running = false;
         while std::time::Instant::now() < deadline {
             if status_generation_running(&scratch) {
@@ -328,7 +325,7 @@ fn active_finite_task_survives_config_save() {
         );
 
         // The slow generation (old revision) completes despite the save.
-        let mut deadline = std::time::Instant::now() + Duration::from_secs(15);
+        let deadline = std::time::Instant::now() + Duration::from_secs(15);
         let mut slow_done = false;
         while std::time::Instant::now() < deadline {
             if scratch.join("slow-verdict.txt").exists() {
@@ -371,7 +368,7 @@ fn socket_path_change_binds_new_before_retiring_old() {
         );
 
         // The NEW socket is live and connectable.
-        let mut deadline = std::time::Instant::now() + Duration::from_secs(10);
+        let deadline = std::time::Instant::now() + Duration::from_secs(10);
         let mut new_connected = false;
         while std::time::Instant::now() < deadline {
             if std::os::unix::net::UnixStream::connect(&scratch.join("sock2")).is_ok() {
@@ -386,7 +383,7 @@ fn socket_path_change_binds_new_before_retiring_old() {
         // the wait observed), so poll instead of asserting on an exact
         // instant — the invariant is eventual removal, never a stale socket
         // left live.
-        let mut deadline = std::time::Instant::now() + Duration::from_secs(10);
+        let deadline = std::time::Instant::now() + Duration::from_secs(10);
         let mut old_retired = false;
         while std::time::Instant::now() < deadline {
             if !scratch.join("sock").exists() {
@@ -430,7 +427,7 @@ fn service_signature_change_replaces_service_without_process_exit() {
         // the old process must be gracefully replaced (new pid file) and the
         // process never exits.
         std::fs::write(scratch.join("src/a.rs"), "x").unwrap();
-        let mut deadline = std::time::Instant::now() + Duration::from_secs(15);
+        let deadline = std::time::Instant::now() + Duration::from_secs(15);
         let mut started = false;
         while std::time::Instant::now() < deadline {
             if scratch.join("svc-ready").exists() {
@@ -451,7 +448,7 @@ fn service_signature_change_replaces_service_without_process_exit() {
         // The reloaded service keeps running (the replaced process touches
         // svc-ready again).
         let _ = std::fs::remove_file(scratch.join("svc-ready"));
-        let mut deadline = std::time::Instant::now() + Duration::from_secs(10);
+        let deadline = std::time::Instant::now() + Duration::from_secs(10);
         let mut replaced = false;
         while std::time::Instant::now() < deadline {
             if scratch.join("svc-ready").exists() {

--- a/tests/control_await.rs
+++ b/tests/control_await.rs
@@ -29,7 +29,7 @@ impl Drop for TestProcess {
         // Graceful SIGTERM first: the watcher's shutdown handler reaps its
         // task process groups, so long-running sleep children never pile up
         // across tests. SIGKILL is the fallback for a stuck watcher.
-        let _ = unsafe { libc_kill(self.child.id() as i32, 15) };
+        let _ = libc_kill(self.child.id() as i32, 15);
         for _ in 0..50 {
             if self.child.try_wait().ok().flatten().is_some() {
                 break;
@@ -122,18 +122,6 @@ fn spawn_cli(directory: &std::path::Path, args: &[&str]) -> Child {
         .expect("fzz control client should spawn")
 }
 
-fn raw_status(socket_path: &std::path::Path) -> serde_json::Value {
-    let mut stream = UnixStream::connect(socket_path).expect("connect control socket");
-    writeln!(
-        stream,
-        r#"{{"jsonrpc":"2.0","id":"status","method":"status"}}"#
-    )
-    .unwrap();
-    let mut line = String::new();
-    BufReader::new(&stream).read_line(&mut line).unwrap();
-    serde_json::from_str(&line).unwrap()
-}
-
 fn try_status(socket_path: &std::path::Path) -> Result<serde_json::Value, String> {
     let mut stream = match UnixStream::connect(socket_path) {
         Ok(stream) => stream,
@@ -161,16 +149,6 @@ fn run_cli_retry(directory: &std::path::Path, args: &[&str]) -> Output {
         last = run_cli(directory, args);
     }
     last
-}
-
-fn wait_until<F: FnMut() -> bool>(mut condition: F) {
-    for _ in 0..300 {
-        if condition() {
-            return;
-        }
-        std::thread::sleep(Duration::from_millis(100));
-    }
-    panic!("wait_until timed out");
 }
 
 fn wait_until_status<F: FnMut(&serde_json::Value) -> bool>(socket: &std::path::Path, mut f: F) {
@@ -349,7 +327,7 @@ fn await_superseded_generation_returns_superseded() {
             && status["state"].as_str() == Some("running")
     });
 
-    let mut waiter = spawn_cli(
+    let waiter = spawn_cli(
         &directory,
         &[
             "control",
@@ -384,7 +362,7 @@ fn await_watcher_disconnect_reports_disconnected() {
     let mut watcher = start_watcher(&directory);
     wait_until_socket(&directory);
 
-    let mut waiter = spawn_cli(
+    let waiter = spawn_cli(
         &directory,
         &["control", "await", "--after", "0", "--timeout", "60s"],
     );
@@ -409,7 +387,7 @@ fn await_watcher_restart_reports_restarted() {
     let socket = directory.join("sock");
     wait_until_status(&socket, |status| status["generation"].as_u64() == Some(1));
 
-    let mut waiter = spawn_cli(
+    let waiter = spawn_cli(
         &directory,
         &["control", "await", "--after", "1", "--timeout", "60s"],
     );
@@ -439,11 +417,11 @@ fn multiple_waiters_all_return_on_one_terminal_event() {
     let _watcher = start_watcher(&directory);
     wait_until_socket(&directory);
 
-    let mut first = spawn_cli(
+    let first = spawn_cli(
         &directory,
         &["control", "await", "--after", "0", "--timeout", "20s"],
     );
-    let mut second = spawn_cli(
+    let second = spawn_cli(
         &directory,
         &["control", "await", "--after", "0", "--timeout", "20s"],
     );
@@ -452,7 +430,7 @@ fn multiple_waiters_all_return_on_one_terminal_event() {
     let trigger = run_cli(&directory, &["control", "emit", "x.txt"]);
     assert!(trigger.status.success());
 
-    for mut waiter in [first, second] {
+    for waiter in [first, second] {
         let output = waiter.wait_with_output().expect("waiter finished");
         assert!(output.status.success(), "waiter must exit 0");
         let stdout = String::from_utf8_lossy(&output.stdout);

--- a/tests/control_identity.rs
+++ b/tests/control_identity.rs
@@ -122,17 +122,6 @@ fn raw_status(socket_path: &std::path::Path) -> serde_json::Value {
     try_status(socket_path).expect("connect control socket")
 }
 
-fn wait_until<F: FnMut() -> bool>(mut condition: F) {
-    let mut last_status = String::new();
-    for _ in 0..250 {
-        if condition() {
-            return;
-        }
-        std::thread::sleep(Duration::from_millis(100));
-    }
-    panic!("wait_until timed out (last status: {last_status})");
-}
-
 const LONG_RUNNING: &str = r#"
 on:
   socket: sock
@@ -201,13 +190,12 @@ fn wait_until_status<F: FnMut(&serde_json::Value) -> bool>(
     socket_path: &std::path::Path,
     mut condition: F,
 ) -> u64 {
-    let mut generation = 0;
     let mut last_error = String::new();
     let mut last_seen = String::new();
     for _ in 0..250 {
         match try_status(socket_path) {
             Ok(status) => {
-                generation = status["result"]["generation"].as_u64().unwrap_or(0);
+                let generation = status["result"]["generation"].as_u64().unwrap_or(0);
                 last_seen = status["result"].to_string();
                 if condition(&status["result"]) {
                     return generation;

--- a/tests/control_reload_identity.rs
+++ b/tests/control_reload_identity.rs
@@ -129,7 +129,7 @@ fn capabilities_instance(socket_path: &std::path::Path) -> serde_json::Value {
 }
 
 fn wait_until<F: FnMut() -> bool>(mut condition: F, what: &str) {
-    let mut deadline = std::time::Instant::now() + Duration::from_secs(20);
+    let deadline = std::time::Instant::now() + Duration::from_secs(20);
     while std::time::Instant::now() < deadline {
         if condition() {
             return;
@@ -141,7 +141,7 @@ fn wait_until<F: FnMut() -> bool>(mut condition: F, what: &str) {
 
 fn wait_for_reload(directory: &std::path::Path, revision: u64) {
     let needle = format!("revision {revision}");
-    let mut deadline = std::time::Instant::now() + Duration::from_secs(20);
+    let deadline = std::time::Instant::now() + Duration::from_secs(20);
     loop {
         if let Ok(log) = std::fs::read_to_string(directory.join("child.err")) {
             if log.contains(&needle) {
@@ -463,7 +463,7 @@ fn invalid_config_publishes_terminal_lifecycle_and_exits_nonzero() {
     std::fs::write(directory.join(".watch.yaml"), "jobs: [unclosed").unwrap();
 
     // The watcher must exit nonzero with the terminal error.
-    let mut deadline = std::time::Instant::now() + Duration::from_secs(20);
+    let deadline = std::time::Instant::now() + Duration::from_secs(20);
     let exit = loop {
         if let Some(status) = watcher.child.try_wait().expect("try_wait") {
             break status;

--- a/tests/control_socket_cli.rs
+++ b/tests/control_socket_cli.rs
@@ -105,7 +105,7 @@ fn call(path: &std::path::Path, request: Value) -> Value {
         BufReader::new(stream).read_line(&mut response).unwrap();
         match serde_json::from_str(&response) {
             Ok(parsed) => return parsed,
-            Err(err) if Instant::now() < deadline => {
+            Err(_) if Instant::now() < deadline => {
                 std::thread::sleep(Duration::from_millis(50));
             }
             Err(err) => panic!(

--- a/tests/future_files.rs
+++ b/tests/future_files.rs
@@ -86,17 +86,6 @@ fn result(response: serde_json::Value) -> serde_json::Value {
     response["result"].clone()
 }
 
-/// Waits until `condition` holds (max ~20s), panicking otherwise.
-fn wait_until<F: FnMut() -> bool>(mut condition: F) {
-    for _ in 0..200 {
-        if condition() {
-            return;
-        }
-        std::thread::sleep(Duration::from_millis(100));
-    }
-    panic!("wait_until timed out");
-}
-
 /// CI debugging aid: on timeout, surface the watcher's captured verbose
 /// output and its final control-socket status before panicking, so a red CI
 /// run is diagnosable from the log without local reproduction.

--- a/tests/jobs_migration.rs
+++ b/tests/jobs_migration.rs
@@ -228,7 +228,7 @@ fn usage_guide_yaml_blocks_parse_through_the_production_parser() {
     let usage = std::fs::read_to_string("docs/USAGE.md").expect("usage guide");
     let advanced = std::fs::read_to_string("docs/ADVANCED-GUIDE.md").expect("advanced guide");
     let hooks = std::fs::read_to_string("docs/RUN-HOOKS-CONTRACT.md").expect("hooks contract");
-    let all = format!("{}\n{advanced}", usage);
+    let all = format!("{usage}\n{advanced}\n{hooks}");
     let mut in_block = false;
     let mut current = String::new();
     let mut parsed = 0;

--- a/tests/run_once.rs
+++ b/tests/run_once.rs
@@ -595,7 +595,6 @@ fn service_task_runs_across_generations_and_shuts_down() {
     // treated as finite work); it survives a change-triggered generation and
     // is reaped on watcher shutdown. Uses a bounded service script so the
     // test never hangs.
-    use std::io::Write;
     use std::time::Duration;
 
     let directory = fixture("service");
@@ -633,7 +632,7 @@ fn service_task_runs_across_generations_and_shuts_down() {
     // ("Watching..." prints inside the on-ready callback) before writing the
     // trigger — a fixed sleep races root registration under debug builds and
     // loses the very first event (never assert on timing).
-    let mut deadline = std::time::Instant::now() + Duration::from_secs(20);
+    let deadline = std::time::Instant::now() + Duration::from_secs(20);
     loop {
         if let Ok(log) = std::fs::read_to_string(directory.join("child.out")) {
             if log.contains("Watching...") {
@@ -650,7 +649,7 @@ fn service_task_runs_across_generations_and_shuts_down() {
     // A change triggers the generation: the finite prep job runs and the
     // service is started and kept running (svc-ready written).
     std::fs::write(directory.join("a.txt"), "change").unwrap();
-    let mut deadline = std::time::Instant::now() + Duration::from_secs(15);
+    let deadline = std::time::Instant::now() + Duration::from_secs(15);
     let mut prepped = false;
     while std::time::Instant::now() < deadline {
         if directory.join("prep.txt").exists() && directory.join("svc-ready").exists() {

--- a/tests/tasks_with_filepath_template.rs
+++ b/tests/tasks_with_filepath_template.rs
@@ -45,9 +45,10 @@ fn test_it_replaces_filepath_template_with_changed_file() {
                         .read_to_string(&mut output)
                         .expect("failed to read from file");
 
-                    output.contains("this file has changed")
-                        && output.contains("foobar-watcher.txt")
-                        && output.contains("Success; Completed")
+                    let visible = setup::strip_ansi_codes(&output);
+                    visible.contains("this file has changed")
+                        && visible.contains("foobar-watcher.txt")
+                        && visible.contains("Success; Completed")
                 },
                 "was not possible to find filepath: {}",
                 output

--- a/tests/watching_configured_rules.rs
+++ b/tests/watching_configured_rules.rs
@@ -1,5 +1,6 @@
 use pretty_assertions::assert_eq;
-use std::io::prelude::*;
+use std::io::{Read, Write};
+#[cfg(feature = "test-integration-file-system")]
 use std::path::PathBuf;
 
 #[path = "./common/lib.rs"]
@@ -11,6 +12,7 @@ mod setup;
 /// Concurrent integration runs (the Funzzy watcher generation, CI, manual
 /// invocations) each get an isolated scratch root, so no run can destroy
 /// another run's watch roots or trigger files.
+#[cfg(feature = "test-integration-file-system")]
 fn scratch_config(template: &str, label: &str) -> (PathBuf, PathBuf, String) {
     let scratch = std::env::temp_dir().join(format!(
         "funzzy-fzz-scratch-{}-{}",
@@ -371,7 +373,7 @@ fn poll_backend_detects_changes_and_runs_tasks() {
     setup::serialized(|| {
         // TASK-0037: `on.watch_backend: poll` drives the same batching/matching
         // path and must detect a file change and run the matching task.
-        use std::io::prelude::*;
+
         use std::time::Duration;
 
         let scratch = std::env::temp_dir().join(format!(
@@ -402,7 +404,7 @@ fn poll_backend_detects_changes_and_runs_tasks() {
 
         std::fs::write(scratch.join("trigger.txt"), "change").unwrap();
 
-        let mut deadline = std::time::Instant::now() + Duration::from_secs(15);
+        let deadline = std::time::Instant::now() + Duration::from_secs(15);
         let mut ran = false;
         while std::time::Instant::now() < deadline {
             if scratch.join("captured.txt").exists() {
@@ -461,7 +463,7 @@ fn gitignored_paths_do_not_trigger_tasks_when_respected() {
         // the full debounce + margin instead of a single fixed sleep, so the
         // assertion is deterministic under load.
         std::fs::write(scratch.join("generated/out.txt"), "change").unwrap();
-        let mut deadline = std::time::Instant::now() + Duration::from_secs(4);
+        let deadline = std::time::Instant::now() + Duration::from_secs(4);
         while std::time::Instant::now() < deadline {
             std::thread::sleep(Duration::from_millis(100));
             assert!(
@@ -472,7 +474,7 @@ fn gitignored_paths_do_not_trigger_tasks_when_respected() {
 
         // A normal file change DOES run the task.
         std::fs::write(scratch.join("real.txt"), "change").unwrap();
-        let mut deadline = std::time::Instant::now() + Duration::from_secs(15);
+        let deadline = std::time::Instant::now() + Duration::from_secs(15);
         let mut ran = false;
         while std::time::Instant::now() < deadline {
             if scratch.join("captured.txt").exists() {
@@ -498,6 +500,7 @@ fn gitignored_paths_do_not_trigger_tasks_when_respected() {
 /// it to a per-run scratch dir. Used with `setup::with_config` so discovery
 /// tests serialize through the harness mutex (never starving harness wait
 /// budgets) and write triggers inside the fixture.
+#[cfg(feature = "test-integration")]
 fn discovery_config(label: &str, change: &str) -> (std::path::PathBuf, std::path::PathBuf) {
     let scratch =
         std::env::temp_dir().join(format!("funzzy-discovery-{}-{}", std::process::id(), label));
@@ -554,7 +557,7 @@ fn newly_created_file_under_existing_watched_dir_triggers_job() {
             )
             .unwrap();
 
-            let mut deadline = std::time::Instant::now() + Duration::from_secs(15);
+            let deadline = std::time::Instant::now() + Duration::from_secs(15);
             let mut ran = false;
             while std::time::Instant::now() < deadline {
                 if fixture.join("captured.txt").exists() {
@@ -609,7 +612,7 @@ fn directory_created_after_startup_becomes_covered_without_restart() {
             std::fs::create_dir_all(fixture.join("examples/workdir/deep/nested")).unwrap();
             std::fs::write(fixture.join("examples/workdir/deep/nested/out.txt"), "x").unwrap();
 
-            let mut deadline = std::time::Instant::now() + Duration::from_secs(15);
+            let deadline = std::time::Instant::now() + Duration::from_secs(15);
             let mut ran = false;
             while std::time::Instant::now() < deadline {
                 if fixture.join("captured.txt").exists() {
@@ -658,7 +661,7 @@ fn delete_and_recreate_stays_observable_without_restart() {
 
             // First creation triggers.
             std::fs::write(&target, "v1").unwrap();
-            let mut deadline = std::time::Instant::now() + Duration::from_secs(15);
+            let deadline = std::time::Instant::now() + Duration::from_secs(15);
             let mut first = false;
             while std::time::Instant::now() < deadline {
                 if captured.exists() {
@@ -673,7 +676,7 @@ fn delete_and_recreate_stays_observable_without_restart() {
             // Delete then recreate: still observable, no restart.
             std::fs::remove_file(&target).unwrap();
             std::fs::write(&target, "v2").unwrap();
-            let mut deadline = std::time::Instant::now() + Duration::from_secs(15);
+            let deadline = std::time::Instant::now() + Duration::from_secs(15);
             let mut second = false;
             while std::time::Instant::now() < deadline {
                 if captured.exists() {
@@ -727,7 +730,7 @@ fn atomic_editor_save_triggers_destination_once_without_temp_leak() {
             std::fs::write(fixture.join("examples/workdir/notes.txt.tmp"), "draft\n").unwrap();
             std::fs::rename(fixture.join("examples/workdir/notes.txt.tmp"), &target).unwrap();
 
-            let mut deadline = std::time::Instant::now() + Duration::from_secs(15);
+            let deadline = std::time::Instant::now() + Duration::from_secs(15);
             let mut ran = false;
             while std::time::Instant::now() < deadline {
                 if fixture.join("captured.txt").exists() {
@@ -741,6 +744,7 @@ fn atomic_editor_save_triggers_destination_once_without_temp_leak() {
     );
 }
 
+#[cfg(feature = "test-integration")]
 fn wait_watching(scratch: &std::path::Path) {
     use std::time::{Duration, Instant};
     let deadline = Instant::now() + Duration::from_secs(20);

--- a/tests/watching_nested_groups.rs
+++ b/tests/watching_nested_groups.rs
@@ -1,5 +1,5 @@
-use pretty_assertions::assert_eq;
-use std::io::prelude::*;
+#[cfg(feature = "test-integration")]
+use std::io::{Read, Write};
 
 #[path = "./common/lib.rs"]
 mod setup;
@@ -9,6 +9,7 @@ mod setup;
 /// into two batches under load, running the task twice; the duplicate echo
 /// must land in the phase that triggered it, not leak into the next phase's
 /// assertion window after `output.truncate(0)`.
+#[cfg(feature = "test-integration")]
 fn drain_until_quiet(output_log: &mut std::fs::File, output: &mut String, quiet_ms: u64) {
     loop {
         let before = output.len();


### PR DESCRIPTION
## Summary

- split the `fzz` alias into its own thin binary adapter so Cargo no longer reports one source file in multiple targets
- remove stale imports, variables, helpers, and unnecessary mutation/unsafe blocks across library and tests
- gate test-only helpers precisely instead of suppressing warnings
- make docs YAML coverage include the hooks contract and make filepath-template readiness ANSI-insensitive
