### PR TITLE
fix(cli): render commands section once in top-level help

### DIFF
--- a/src/arguments.rs
+++ b/src/arguments.rs
@@ -844,17 +844,7 @@ Alias:
 
 {usage-heading} {usage}
 
-Commands:
-  init                Create or migrate a '.watch.yaml' file.
-  watch [TARGET]      Watch for file changes and run configured tasks.
-  list                List configured tasks.
-  run TARGET          Run configured tasks once locally, without watcher IPC.
-  explain PATH        Show which tasks a path matches or is ignored by.
-  exec                Run an ad-hoc command over stdin-supplied paths.
-  control             Interact with a running watcher over its control socket.
-
 {all-args}
-
 Environment configs:
   FUNZZY_NON_BLOCK        Same as `--on-busy restart`
   FUNZZY_BAIL             Same as `--fail-fast`
@@ -1816,6 +1806,40 @@ mod config_command_tests {
         assert!(parse(&["config", "schema", "--section", "bogus"]).is_err());
         assert!(parse(&["config", "example", "bogus"]).is_err());
         assert!(parse(&["config", "example"]).is_err());
+    }
+
+    // -------------------------------------------------------------------
+    // Help rendering
+    // -------------------------------------------------------------------
+
+    #[test]
+    fn help_text_renders_commands_section_once_and_complete() {
+        let help = super::Arguments::help_text();
+        assert_eq!(
+            help.matches("Commands:").count(),
+            1,
+            "commands section must be rendered by clap only, not duplicated:\n{help}"
+        );
+        // The single clap-generated section must list every subcommand,
+        // including the ones the stale hand-written list used to miss.
+        for expected in [
+            "init",
+            "watch",
+            "list",
+            "run",
+            "check",
+            "completions",
+            "config",
+            "explain",
+            "exec",
+            "control",
+            "ctl",
+        ] {
+            assert!(
+                help.contains(expected),
+                "help must mention {expected}:\n{help}"
+            );
+        }
     }
 }
 

--- a/tests/cli_arguments.rs
+++ b/tests/cli_arguments.rs
@@ -73,7 +73,11 @@ fn help_shows_usage_commands_and_options_for_both_binaries() {
             .stdout(predicate::str::contains("--verbose"))
             .stdout(predicate::str::contains("--on-busy"))
             .stdout(predicate::str::contains("--control-socket"))
-            .stdout(predicate::str::contains("run TARGET"));
+            // The clap-generated commands section lists every subcommand
+            // (check/completions/config included) and `run` takes its
+            // TARGET argument; `fzz run --help` shows the <TARGET> usage.
+            .stdout(predicate::str::contains("  run"))
+            .stdout(predicate::str::contains("  check"));
     }
 }
 

--- a/tests/tasks_with_filepath_template.rs
+++ b/tests/tasks_with_filepath_template.rs
@@ -39,20 +39,6 @@ fn test_it_replaces_filepath_template_with_changed_file() {
 
             write_to_file!(fixture.join("examples/workdir/trigger-watcher.txt"));
 
-            wait_until!(
-                {
-                    output_log
-                        .read_to_string(&mut output)
-                        .expect("failed to read from file");
-
-                    output.contains("this file has changed")
-                        && output.contains("foobar-watcher.txt")
-                        && output.contains("Success; Completed")
-                },
-                "was not possible to find filepath: {}",
-                output
-            );
-
             let dir = fixture;
             let expected = "Funzzy: Running on init commands.
 
@@ -82,11 +68,26 @@ Funzzy: echo '$PWD/examples/workdir/trigger-watcher.txt' | sed -r s/trigger/foob
 
 $PWD/examples/workdir/foobar-watcher.txt
 Funzzy results ----------------------------
-Success; Completed: 3; Failed: 0; Duration: 0.0000s";
+Success; Completed: 3; Failed: 0; Duration: 0.0000s"
+                .replace("$PWD", &dir.to_string_lossy());
+
+            // Waiting for individual markers races the final summary flush;
+            // wait until the whole log settles to the expected content.
+            wait_until!(
+                {
+                    output_log
+                        .read_to_string(&mut output)
+                        .expect("failed to read from file");
+
+                    setup::strip_ansi_codes(&setup::clean_output(&output)) == expected
+                },
+                "was not possible to find filepath: {}",
+                output
+            );
 
             assert_eq!(
                 setup::strip_ansi_codes(&setup::clean_output(&output)),
-                expected.replace("$PWD", &dir.to_string_lossy())
+                expected
             )
         },
     );
@@ -125,19 +126,6 @@ fn it_replaces_relative_path_relative_to_the_cunrrent_dir() {
             );
 
             write_to_file!(fixture.join("examples/workdir/trigger-watcher.txt"));
-
-            wait_until!(
-                {
-                    output_log
-                        .read_to_string(&mut output)
-                        .expect("failed to read from file");
-
-                    output.contains("echo 'examples/workdir/trigger-watcher.txt'")
-                        && output.match_indices("Funzzy results").count() == 2
-                },
-                "output: {}\nreason: was not possible to echo with relative path",
-                output
-            );
 
             let dir = fixture;
             let expected = "Funzzy: Running on init commands.
@@ -178,11 +166,26 @@ Funzzy: echo 'this is invalid: {{ foobar }} (no!)'
 
 this is invalid: {{ foobar }} (no!)
 Funzzy results ----------------------------
-Success; Completed: 4; Failed: 0; Duration: 0.0000s";
+Success; Completed: 4; Failed: 0; Duration: 0.0000s"
+                .replace("$PWD", &dir.to_string_lossy());
+
+            // Same as the absolute-path test: wait for the whole log to
+            // settle to the expected content, not just marker lines.
+            wait_until!(
+                {
+                    output_log
+                        .read_to_string(&mut output)
+                        .expect("failed to read from file");
+
+                    setup::strip_ansi_codes(&setup::clean_output(&output)) == expected
+                },
+                "output: {}\nreason: was not possible to echo with relative path",
+                output
+            );
 
             assert_eq!(
                 setup::strip_ansi_codes(&setup::clean_output(&output)),
-                expected.replace("$PWD", &dir.to_string_lossy())
+                expected
             )
         },
     );

--- a/tests/watching_with_non_block_flag.rs
+++ b/tests/watching_with_non_block_flag.rs
@@ -57,20 +57,10 @@ fn test_it_cancel_current_running_task_when_something_change() {
 
             write_to_file!(fixture.join("examples/workdir/trigger-watcher.txt"));
 
-            wait_until!(
-                {
-                    output_log
-                        .read_to_string(&mut output)
-                        .expect("failed to read from file");
-
-                    // See it in `examples/longtask.sh`
-                    // and also in `src/stdout.rs`
-                    output.match_indices(CLEAR_SCREEN).count() == 2
-                },
-                "Failed to find 2 clear screen signs: {}",
-                output
-            );
-
+            // Waiting for the second clear screen alone races the log writer:
+            // the screen is printed before the restarted run's banner and
+            // first tick flush. Wait until the whole log settles to the
+            // expected content instead.
             let expected = "Funzzy: Running on init commands.
 
 Funzzy: bash examples/longtask.sh long 2 
@@ -90,6 +80,18 @@ Funzzy: bash examples/longtask.sh long 1
 Started task long 1
 Long task running... 0
 ";
+
+            wait_until!(
+                {
+                    output_log
+                        .read_to_string(&mut output)
+                        .expect("failed to read from file");
+
+                    setup::strip_ansi_codes(&output) == expected
+                },
+                "Failed to settle on the expected full output: {}",
+                output
+            );
 
             assert_eq!(
                 setup::strip_ansi_codes(&output),
@@ -154,20 +156,9 @@ fn test_it_cancel_current_running_task_when_something_change_with_env() {
 
                     write_to_file!(fixture.join("examples/workdir/trigger-watcher.txt"));
 
-                    wait_until!(
-                        {
-                            output_log
-                                .read_to_string(&mut output)
-                                .expect("failed to read from file");
-
-                            // See it in `examples/longtask.sh`
-                            // and also in `src/stdout.rs`
-                            output.match_indices(CLEAR_SCREEN).count() == 2
-                        },
-                        "Failed to find 2 clear screen signs: {}",
-                        output
-                    );
-
+                    // Same as the flag test above: wait for the whole
+                    // log to settle to the expected content, not just the
+                    // second clear screen.
                     let expected = "Funzzy: Running on init commands.
 
 Funzzy: bash examples/longtask.sh long 2 
@@ -187,6 +178,18 @@ Funzzy: bash examples/longtask.sh long 1
 Started task long 1
 Long task running... 0
 ";
+
+                    wait_until!(
+                        {
+                            output_log
+                                .read_to_string(&mut output)
+                                .expect("failed to read from file");
+
+                            setup::strip_ansi_codes(&output) == expected
+                        },
+                        "Failed to settle on the expected full output: {}",
+                        output
+                    );
 
                     assert_eq!(
                         setup::strip_ansi_codes(&output),


### PR DESCRIPTION
## Problem

`fzz -h` printed the `Commands:` section twice: `HELP_TEMPLATE` hardcoded a hand-written list, then `{all-args}` rendered clap's own generated list right after it. The hand-written list had also drifted from reality — missing `check`, `completions`, `config`, and the `ctl` alias.
