### PR TITLE
fix(cli): render commands section once in top-level help

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,15 +16,16 @@ One YAML workflow works for developers, coding agents, and CI. Use `fzz run TARG
 > V2 is unreleased on `develop`. See [V1](https://github.com/cristianoliveira/funzzy/tree/v1) when using v1.5.0.
 
 
-For ad-hoc work over paths from stdin:
+As simple as:
 
 ```bash
 find . -name '*.ts' | fzz exec -- npx eslint {{relative_filepath}}
 ```
 
-For a configured workflow, create `.watch.yaml`:
+Or for more complex workflows like:
 
 ```yaml
+# .watch.yml
 on:
   change: ["src/**", "tests/**"]
   ignore: ["target/**", "**/*.log"]

--- a/README.md
+++ b/README.md
@@ -10,13 +10,13 @@ fzz check   # validate it
 fzz         # watch, run, repeat
 ```
 
-One YAML workflow works for developers, coding agents, and CI. Use `fzz run TARGET` for finite execution or control a running watcher through a deterministic, machine-readable API.
+One YAML workflow works for developers and coding agents. Use `fzz run TARGET` for finite execution or control a running watcher through a deterministic, machine-readable API.
 
 > [!WARNING]
 > V2 is unreleased on `develop`. See [V1](https://github.com/cristianoliveira/funzzy/tree/v1) when using v1.5.0.
 
 
-As simple as:
+For a workflow as simple as:
 
 ```bash
 find . -name '*.ts' | fzz exec -- npx eslint {{relative_filepath}}

--- a/plans/done/0084-refresh-the-v2-0-0-candidate-after-output-axi-hardening.md
+++ b/plans/done/0084-refresh-the-v2-0-0-candidate-after-output-axi-hardening.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-0084
 title: Refresh the v2.0.0 candidate after output AXI hardening
-status: doing
+status: done
 depends_on: [TASK-0083, TASK-0087, TASK-0092, TASK-0095, TASK-0062]
 priority: high
 tags: [release, v2, candidate, axi, pi-watcher, verification]

--- a/plans/todo/0096-define-complete-removal-boundary-for-docs-drift-apparatus.md
+++ b/plans/todo/0096-define-complete-removal-boundary-for-docs-drift-apparatus.md
@@ -1,0 +1,34 @@
+---
+id: TASK-0096
+title: Define complete removal boundary for docs drift apparatus
+status: todo
+depends_on: [TASK-0069, TASK-0095]
+priority: high
+tags: [design, docs, cleanup, ci, determinism]
+---
+
+# Define complete removal boundary for docs drift apparatus
+
+## Problem
+The docs-drift mechanism is a bad nondeterministic meta-gate that conditionally reuses binaries, launches nested builds/tests, scans prose with shell regexes, and couples documentation to release/workspace state; we want deletion, not redesign.
+
+## Context
+
+Scope selected explicitly: remove docs-drift only. Keep `scripts/version-check`, `scripts/version-check-test`, Nix bump helpers, and Git hook helper.
+
+## Acceptance criteria
+
+- [ ] Removal inventory names `scripts/docs-drift-check`, `make docs-drift`, push/release workflow calls and labels, `scripts/golden/init-template.yaml`, and tests/docs whose only purpose is generic docs-drift enforcement.
+- [ ] No replacement umbrella script, generated-doc checker, internal-link checker, stale-vocabulary scanner, or docs-drift CI gate is proposed.
+- [ ] Delete conditional stale `target/debug/fzz` reuse, nested Cargo invocations, Markdown/prose regex scans, temporary generated-file comparison, version-check delegation, and aggregated `DRIFT:` diagnostics as one apparatus.
+- [ ] Product behavior tests remain when they verify runtime behavior directly (config parser accepts/rejects fields, `fzz init` creates runnable config, examples used by product); byte-for-byte documentation/golden policing is removed.
+- [ ] Distinguish docs-only test from product contract test file-by-file before deletion; rationale is recorded for ambiguous `jobs_migration`, `command_init`, catalog parity, and init proof cases.
+- [ ] `version-check` and release tag/Cargo/Cargo.lock identity checks remain independently owned and never become part of this removal.
+- [ ] No change to generated `.watch.yaml` production content is included; removal only stops generic drift policing.
+- [ ] Historical completed plan/report records may mention TASK-0069 but are not executable references and need not be rewritten.
+- [ ] Current user/contributor docs must stop promising a docs-drift gate or `make docs-drift` command.
+- [ ] Exact deletion list and retained safety checks are reviewed before implementation.
+
+## Notes
+
+This task intentionally chooses deletion over making docs-drift deterministic.

--- a/plans/todo/0097-delete-docs-drift-script-golden-and-workflow-wiring.md
+++ b/plans/todo/0097-delete-docs-drift-script-golden-and-workflow-wiring.md
@@ -1,0 +1,32 @@
+---
+id: TASK-0097
+title: Delete docs drift script golden and workflow wiring
+status: todo
+depends_on: [TASK-0096]
+priority: high
+tags: [docs, cleanup, ci, makefile, github-actions]
+---
+
+# Delete docs drift script golden and workflow wiring
+
+## Problem
+Keeping fragments after deleting the umbrella script would leave misleading Make targets CI names golden snapshots tests and documentation claims that imply the bad gate still exists.
+
+## Context
+
+Remove all live entry points in one change so no command or CI label points to missing behavior.
+
+## Acceptance criteria
+
+- [ ] Delete `scripts/docs-drift-check` and `scripts/golden/init-template.yaml`; remove empty `scripts/golden` directory.
+- [ ] Delete `docs-drift` target and `.PHONY` declaration from Makefile.
+- [ ] Remove Docs/CLI/schema/example drift step from `.github/workflows/on-push.yml` without replacement.
+- [ ] Remove `make docs-drift` from release workflow and rename combined “Version + docs drift” step to describe retained exact version/tag identity only.
+- [ ] Remove direct byte-golden init test and docs-only size/snapshot assertions that depend on deleted golden; retain behavioral `fzz init` create/check/run tests.
+- [ ] Remove broad examples/doc-block drift tests only when TASK-0096 classifies them as docs policing; retain focused migration/parser behavior tests.
+- [ ] Remove current README/docs/Make help references that advertise generic docs drift prevention or command, while keeping installed schema/init documentation truthful.
+- [ ] Do not alter `scripts/version-check`, `scripts/version-check-test`, their Make targets, or release identity shell assertions.
+- [ ] Do not add replacement shell/Python/Rust meta-check or snapshot framework.
+- [ ] Production source and generated init output remain byte-identical unless compilation requires deleting dead test-only exposure.
+
+## Notes

--- a/plans/todo/0098-prove-docs-drift-apparatus-is-gone-without-changing-runtime-behavior.md
+++ b/plans/todo/0098-prove-docs-drift-apparatus-is-gone-without-changing-runtime-behavior.md
@@ -1,0 +1,32 @@
+---
+id: TASK-0098
+title: Prove docs drift apparatus is gone without changing runtime behavior
+status: todo
+depends_on: [TASK-0097, TASK-0061]
+priority: high
+tags: [tests, docs, cleanup, ci, regression]
+---
+
+# Prove docs drift apparatus is gone without changing runtime behavior
+
+## Problem
+Removal must be complete and must not accidentally remove version release checks or alter fzz init config parsing CLI watcher and packaging behavior.
+
+## Context
+
+Verification is a one-time removal audit plus existing normal project gates, not a new permanent docs checker.
+
+## Acceptance criteria
+
+- [ ] Repository search finds no live `docs-drift`, `docs-drift-check`, `make docs-drift`, generic `DRIFT:` diagnostic, or `scripts/golden/init-template.yaml` reference outside historical plans/reports.
+- [ ] `scripts/` retains only independently justified version, Nix bump, and Git hook helpers; no generated-doc/check replacement is introduced.
+- [ ] Make help and GitHub workflow YAML parse and contain no dangling/renamed docs gate.
+- [ ] Existing focused tests prove `fzz init` creates valid generic try-it-now config, refuses overwrite, handles custom filename/migration, and production parser/schema behavior remains unchanged.
+- [ ] `scripts/version-check-test` still passes and release workflow retains Cargo/Cargo.lock/exact-tag checks.
+- [ ] Unit, focused init/config tests, formatting, and ordinary CI checks pass without invoking removed script.
+- [ ] No test reads a pre-existing `target/debug/fzz` as documentation truth or requires deleted golden path.
+- [ ] Git diff confirms no runtime config, watcher, control protocol, CLI argument, schema, or init-template content changed.
+- [ ] Removal report lists deleted checks plainly without claiming equivalent replacement coverage.
+- [ ] External watcher final gate passes from unchanged worktree fingerprint.
+
+## Notes

--- a/src/arguments.rs
+++ b/src/arguments.rs
@@ -835,17 +835,7 @@ Alias:
 
 {usage-heading} {usage}
 
-Commands:
-  init                Create or migrate a '.watch.yaml' file.
-  watch [TARGET]      Watch for file changes and run configured tasks.
-  list                List configured tasks.
-  run TARGET          Run configured tasks once locally, without watcher IPC.
-  explain PATH        Show which tasks a path matches or is ignored by.
-  exec                Run an ad-hoc command over stdin-supplied paths.
-  control             Interact with a running watcher over its control socket.
-
 {all-args}
-
 Environment configs:
   FUNZZY_NON_BLOCK        Same as `--on-busy restart`
   FUNZZY_BAIL             Same as `--fail-fast`
@@ -1807,6 +1797,40 @@ mod config_command_tests {
         assert!(parse(&["config", "schema", "--section", "bogus"]).is_err());
         assert!(parse(&["config", "example", "bogus"]).is_err());
         assert!(parse(&["config", "example"]).is_err());
+    }
+
+    // -------------------------------------------------------------------
+    // Help rendering
+    // -------------------------------------------------------------------
+
+    #[test]
+    fn help_text_renders_commands_section_once_and_complete() {
+        let help = super::Arguments::help_text();
+        assert_eq!(
+            help.matches("Commands:").count(),
+            1,
+            "commands section must be rendered by clap only, not duplicated:\n{help}"
+        );
+        // The single clap-generated section must list every subcommand,
+        // including the ones the stale hand-written list used to miss.
+        for expected in [
+            "init",
+            "watch",
+            "list",
+            "run",
+            "check",
+            "completions",
+            "config",
+            "explain",
+            "exec",
+            "control",
+            "ctl",
+        ] {
+            assert!(
+                help.contains(expected),
+                "help must mention {expected}:\n{help}"
+            );
+        }
     }
 }
 

--- a/tests/cli_arguments.rs
+++ b/tests/cli_arguments.rs
@@ -73,7 +73,11 @@ fn help_shows_usage_commands_and_options_for_both_binaries() {
             .stdout(predicate::str::contains("--verbose"))
             .stdout(predicate::str::contains("--on-busy"))
             .stdout(predicate::str::contains("--control-socket"))
-            .stdout(predicate::str::contains("run TARGET"));
+            // The clap-generated commands section lists every subcommand
+            // (check/completions/config included) and `run` takes its
+            // TARGET argument; `fzz run --help` shows the <TARGET> usage.
+            .stdout(predicate::str::contains("  run"))
+            .stdout(predicate::str::contains("  check"));
     }
 }
 

--- a/tests/tasks_with_filepath_template.rs
+++ b/tests/tasks_with_filepath_template.rs
@@ -39,21 +39,6 @@ fn test_it_replaces_filepath_template_with_changed_file() {
 
             write_to_file!(fixture.join("examples/workdir/trigger-watcher.txt"));
 
-            wait_until!(
-                {
-                    output_log
-                        .read_to_string(&mut output)
-                        .expect("failed to read from file");
-
-                    let visible = setup::strip_ansi_codes(&output);
-                    visible.contains("this file has changed")
-                        && visible.contains("foobar-watcher.txt")
-                        && visible.contains("Success; Completed")
-                },
-                "was not possible to find filepath: {}",
-                output
-            );
-
             let dir = fixture;
             let expected = "Funzzy: Running on init commands.
 
@@ -83,11 +68,26 @@ Funzzy: echo '$PWD/examples/workdir/trigger-watcher.txt' | sed -r s/trigger/foob
 
 $PWD/examples/workdir/foobar-watcher.txt
 Funzzy results ----------------------------
-Success; Completed: 3; Failed: 0; Duration: 0.0000s";
+Success; Completed: 3; Failed: 0; Duration: 0.0000s"
+                .replace("$PWD", &dir.to_string_lossy());
+
+            // Waiting for individual markers races the final summary flush;
+            // wait until the whole log settles to the expected content.
+            wait_until!(
+                {
+                    output_log
+                        .read_to_string(&mut output)
+                        .expect("failed to read from file");
+
+                    setup::strip_ansi_codes(&setup::clean_output(&output)) == expected
+                },
+                "was not possible to find filepath: {}",
+                output
+            );
 
             assert_eq!(
                 setup::strip_ansi_codes(&setup::clean_output(&output)),
-                expected.replace("$PWD", &dir.to_string_lossy())
+                expected
             )
         },
     );
@@ -126,19 +126,6 @@ fn it_replaces_relative_path_relative_to_the_cunrrent_dir() {
             );
 
             write_to_file!(fixture.join("examples/workdir/trigger-watcher.txt"));
-
-            wait_until!(
-                {
-                    output_log
-                        .read_to_string(&mut output)
-                        .expect("failed to read from file");
-
-                    output.contains("echo 'examples/workdir/trigger-watcher.txt'")
-                        && output.match_indices("Funzzy results").count() == 2
-                },
-                "output: {}\nreason: was not possible to echo with relative path",
-                output
-            );
 
             let dir = fixture;
             let expected = "Funzzy: Running on init commands.
@@ -179,11 +166,26 @@ Funzzy: echo 'this is invalid: {{ foobar }} (no!)'
 
 this is invalid: {{ foobar }} (no!)
 Funzzy results ----------------------------
-Success; Completed: 4; Failed: 0; Duration: 0.0000s";
+Success; Completed: 4; Failed: 0; Duration: 0.0000s"
+                .replace("$PWD", &dir.to_string_lossy());
+
+            // Same as the absolute-path test: wait for the whole log to
+            // settle to the expected content, not just marker lines.
+            wait_until!(
+                {
+                    output_log
+                        .read_to_string(&mut output)
+                        .expect("failed to read from file");
+
+                    setup::strip_ansi_codes(&setup::clean_output(&output)) == expected
+                },
+                "output: {}\nreason: was not possible to echo with relative path",
+                output
+            );
 
             assert_eq!(
                 setup::strip_ansi_codes(&setup::clean_output(&output)),
-                expected.replace("$PWD", &dir.to_string_lossy())
+                expected
             )
         },
     );

--- a/tests/watching_with_non_block_flag.rs
+++ b/tests/watching_with_non_block_flag.rs
@@ -57,20 +57,10 @@ fn test_it_cancel_current_running_task_when_something_change() {
 
             write_to_file!(fixture.join("examples/workdir/trigger-watcher.txt"));
 
-            wait_until!(
-                {
-                    output_log
-                        .read_to_string(&mut output)
-                        .expect("failed to read from file");
-
-                    // See it in `examples/longtask.sh`
-                    // and also in `src/stdout.rs`
-                    output.match_indices(CLEAR_SCREEN).count() == 2
-                },
-                "Failed to find 2 clear screen signs: {}",
-                output
-            );
-
+            // Waiting for the second clear screen alone races the log writer:
+            // the screen is printed before the restarted run's banner and
+            // first tick flush. Wait until the whole log settles to the
+            // expected content instead.
             let expected = "Funzzy: Running on init commands.
 
 Funzzy: bash examples/longtask.sh long 2 
@@ -90,6 +80,18 @@ Funzzy: bash examples/longtask.sh long 1
 Started task long 1
 Long task running... 0
 ";
+
+            wait_until!(
+                {
+                    output_log
+                        .read_to_string(&mut output)
+                        .expect("failed to read from file");
+
+                    setup::strip_ansi_codes(&output) == expected
+                },
+                "Failed to settle on the expected full output: {}",
+                output
+            );
 
             assert_eq!(
                 setup::strip_ansi_codes(&output),
@@ -154,20 +156,9 @@ fn test_it_cancel_current_running_task_when_something_change_with_env() {
 
                     write_to_file!(fixture.join("examples/workdir/trigger-watcher.txt"));
 
-                    wait_until!(
-                        {
-                            output_log
-                                .read_to_string(&mut output)
-                                .expect("failed to read from file");
-
-                            // See it in `examples/longtask.sh`
-                            // and also in `src/stdout.rs`
-                            output.match_indices(CLEAR_SCREEN).count() == 2
-                        },
-                        "Failed to find 2 clear screen signs: {}",
-                        output
-                    );
-
+                    // Same as the flag test above: wait for the whole
+                    // log to settle to the expected content, not just the
+                    // second clear screen.
                     let expected = "Funzzy: Running on init commands.
 
 Funzzy: bash examples/longtask.sh long 2 
@@ -187,6 +178,18 @@ Funzzy: bash examples/longtask.sh long 1
 Started task long 1
 Long task running... 0
 ";
+
+                    wait_until!(
+                        {
+                            output_log
+                                .read_to_string(&mut output)
+                                .expect("failed to read from file");
+
+                            setup::strip_ansi_codes(&output) == expected
+                        },
+                        "Failed to settle on the expected full output: {}",
+                        output
+                    );
 
                     assert_eq!(
                         setup::strip_ansi_codes(&output),


### PR DESCRIPTION
## Summary

- render the CLI commands section once in top-level help
- simplify README workflow guidance and track docs-drift removal work
- make filepath-template integration assertions wait for exact settled output

## Testing

- `cargo fmt --all`
- `cargo test`
- `make docs-drift`

All passed in Funzzy generation 19.
