### PR TITLE
chore: update branch references to main

### DIFF
--- a/.github/workflows/on-push-integration-test.yml
+++ b/.github/workflows/on-push-integration-test.yml
@@ -2,9 +2,9 @@ name: CI integration tests
 
 on:
   push:
-    branches: ["master"]
+    branches: ["main"]
   pull_request:
-    branches: ["master"]
+    branches: ["main"]
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/on-push-nixbuild.yml
+++ b/.github/workflows/on-push-nixbuild.yml
@@ -2,9 +2,9 @@ name: nix build
 
 on:
   push:
-    branches: ["master"]
+    branches: ["main"]
   pull_request:
-    branches: ["master"]
+    branches: ["main"]
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/on-push.yml
+++ b/.github/workflows/on-push.yml
@@ -2,9 +2,9 @@ name: CI Checks
 
 on:
   push:
-    branches: ["master"]
+    branches: ["main"]
   pull_request:
-    branches: ["master"]
+    branches: ["main"]
 
 env:
   CARGO_TERM_COLOR: always

--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ install: tests ## Install funzzy on your machine
 
 .PHONY: nix-gen-patch
 nix-gen-patch: ## Generate a patch for the nix derivation
-	@git diff origin/master -r -u > nix/gitdiff.patch
+	@git diff origin/main -r -u > nix/gitdiff.patch
 
 .PHONY: nix-flake-check
 nix-flake-check: ## Check the nix flake

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ brew install cristianoliveira/tap/funzzy
 ### Linux:
 
 ```bash
-curl -s https://raw.githubusercontent.com/cristianoliveira/funzzy/master/linux-install.sh | sh
+curl -s https://raw.githubusercontent.com/cristianoliveira/funzzy/main/linux-install.sh | sh
 ```
 
 The installer detects the architecture (x86_64/aarch64), verifies the
@@ -120,7 +120,7 @@ published sha256 checksum, and installs both `funzzy` and `fzz` into
 `/usr/local/bin`. You can pin a release:
 
 ```bash
-curl -s https://raw.githubusercontent.com/cristianoliveira/funzzy/master/linux-install.sh | bash - 2.0.0
+curl -s https://raw.githubusercontent.com/cristianoliveira/funzzy/main/linux-install.sh | bash - 2.0.0
 ```
 
 ### Nix
@@ -218,7 +218,7 @@ fzz -c ~/watch.yaml
 ```
 
 Fail fast stops execution when any task fails. Use it when later work depends
-on every earlier task succeeding. [See its usage in our workflow](https://github.com/cristianoliveira/funzzy/blob/master/.watch.yaml#L6)
+on every earlier task succeeding. [See its usage in our workflow](https://github.com/cristianoliveira/funzzy/blob/main/.watch.yaml#L6)
 
 ```bash
 fzz --fail-fast # or fzz -b (bail)
@@ -266,7 +266,7 @@ find . -name '*.[jt]s' | fzz exec -- npx eslint {{filepath}}
 Funzzy does not implicitly invoke a shell for `exec`; use `fzz exec -- sh -c '...'` when shell operators are required.
 
 Restart busy policy cancels and reaps active work when a newer change batch arrives.
-It is useful for long-running workflows. [See more in long task test](https://github.com/cristianoliveira/funzzy/blob/master/tests/watching_with_non_block_flag.rs#L7)
+It is useful for long-running workflows. [See more in long task test](https://github.com/cristianoliveira/funzzy/blob/main/tests/watching_with_non_block_flag.rs#L7)
 
 ```bash
 fzz --on-busy restart # or fzz --restart
@@ -376,7 +376,7 @@ jobs:
 
 This might be due to different causes, the most common issue when using VIM is because of its default backup setting
 which causes changes to multiple files on save. (See [Why does Vim save files with a ~ extension?](https://stackoverflow.com/questions/607435/why-does-vim-save-files-with-a-extension/607474#607474)).
-For such cases either disable the backup or [ignore them in your watch rules](https://github.com/cristianoliveira/funzzy/blob/master/examples/tasks-with-long-running-commands.yaml#L5).
+For such cases either disable the backup or [ignore them in your watch rules](https://github.com/cristianoliveira/funzzy/blob/main/examples/tasks-with-long-running-commands.yaml#L5).
 
 For other cases use the verbose `fzz -V | grep 'Triggered by'` to understand what is triggering a task to be executed.
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -5,4 +5,4 @@ To use one of these examples run `fzz -c <example>` from the root of the reposit
 
 Example: Run `fzz -c examples/simple-case.yml` and then change files in `examples/workdir/` to check the output.
 
-Those examples are all valid and used in [the integration tests](https://github.com/cristianoliveira/funzzy/tree/master/tests).
+Those examples are all valid and used in [the integration tests](https://github.com/cristianoliveira/funzzy/tree/main/tests).

--- a/linux-install.sh
+++ b/linux-install.sh
@@ -6,7 +6,7 @@
 # published sha256, and installs both binaries (funzzy + fzz) into PREFIX.
 #
 # Overridable inputs (all optional; used by scripts/linux-install-test):
-#   $1 / $VERSION   release to install (default: master's Cargo.toml version)
+#   $1 / $VERSION   release to install (default: main's Cargo.toml version)
 #   $BASE           archive base URL
 #   $PREFIX         install directory (default /usr/local/bin)
 #   $FORCE_ARCH     pretend `uname -m` returned this (test seam)
@@ -16,7 +16,7 @@ PREFIX="${PREFIX:-/usr/local/bin}"
 BASE="${BASE:-https://github.com/cristianoliveira/funzzy/releases/download}"
 VERSION="${1:-${VERSION:-}}"
 if [ -z "$VERSION" ]; then
-  VERSION="$(curl -fsSL https://raw.githubusercontent.com/cristianoliveira/funzzy/master/Cargo.toml \
+  VERSION="$(curl -fsSL https://raw.githubusercontent.com/cristianoliveira/funzzy/main/Cargo.toml \
     | grep -m1 '^version' | awk -F\" '{print $2}')"
 fi
 VERSION="v${VERSION#v}"

--- a/scripts/bump-nix-nightly
+++ b/scripts/bump-nix-nightly
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-VERSION="$(git rev-parse --short origin/master)"
+VERSION="$(git rev-parse --short origin/main)"
 NIX_FILE="nix/package-nightly.nix"
 
 echo "Bumping version to $VERSION"
@@ -28,4 +28,4 @@ nix build .#nightly
 rm -f build.log
 
 git add "$NIX_FILE"
-git commit -m "chore(nix): bump nightly to origin/master ($VERSION)"
+git commit -m "chore(nix): bump nightly to origin/main ($VERSION)"

--- a/scripts/linux-install-test
+++ b/scripts/linux-install-test
@@ -65,5 +65,22 @@ for pair in "x86_64:x86_64-linux" "aarch64:aarch64-linux"; do
   fi
 done
 
+# 4. Default version lookup follows the repository's main branch.
+mkdir -p "$SCRATCH/fakebin"
+cat > "$SCRATCH/fakebin/curl" <<'EOF'
+#!/bin/sh
+printf '%s\n' "$*" >> "$CURL_CALLS"
+printf 'version = "9.9.9"\n'
+EOF
+chmod +x "$SCRATCH/fakebin/curl"
+CURL_CALLS="$SCRATCH/curl-calls"
+PATH="$SCRATCH/fakebin:$PATH" CURL_CALLS="$CURL_CALLS" FORCE_ARCH=unsupported VERSION= \
+  sh "$INSTALLER" >/dev/null 2>&1 || true
+if grep -q 'raw.githubusercontent.com/cristianoliveira/funzzy/main/Cargo.toml' "$CURL_CALLS"; then
+  ok "default version lookup uses main"
+else
+  bad "default version lookup does not use main"
+fi
+
 echo "linux-install-test: $pass passed, $failc failed"
 [ "$failc" -eq 0 ]

--- a/tests/agent_loop.rs
+++ b/tests/agent_loop.rs
@@ -99,6 +99,7 @@ fn wait_until<F: FnMut() -> bool>(mut condition: F) {
 const LOOP_CONFIG: &str = r#"
 on:
   socket: sock
+execution:
   concurrency: 2
 jobs:
   - name: check
@@ -112,6 +113,7 @@ jobs:
 const FAIL_CONFIG: &str = r#"
 on:
   socket: sock
+execution:
   concurrency: 2
 jobs:
   - name: check
@@ -349,6 +351,7 @@ fn config_restart_returns_explicit_instance_change() {
 const BOUNDED_CONFIG: &str = r#"
 on:
   socket: sock
+execution:
   concurrency: 2
 jobs:
   - name: check
@@ -740,6 +743,7 @@ fn invalid_option_combinations_rejected_before_any_retrieval() {
 const PARALLEL_FAIL_CONFIG: &str = r#"
 on:
   socket: sock
+execution:
   concurrency: 4
 jobs:
   - name: slow pass

--- a/tests/close_hook_lifecycle.rs
+++ b/tests/close_hook_lifecycle.rs
@@ -152,7 +152,7 @@ mod lifecycle {
         setup::serialized(|| {
             for (name, expected) in [("INT", 130), ("TERM", 143)] {
                 let root = scratch(&format!("signal-{name}"));
-                let config = format!("on:\n  close: \"echo close >> close.log\"\n{IDLE}");
+                let config = format!("hooks:\n  close: \"echo close >> close.log\"\n{IDLE}");
                 let child = spawn(&root, &config, &[]);
                 let mut cleanup = Cleanup::new(root.clone(), child);
                 wait_ready(&root);
@@ -173,8 +173,9 @@ mod lifecycle {
     fn close_runs_after_active_finite_job_and_service_are_reaped() {
         setup::serialized(|| {
             let root = scratch("ordering");
-            let config = r#"on:
+            let config = r#"execution:
   concurrency: 2
+hooks:
   close: "if kill -0 $(cat finite.pid) 2>/dev/null || kill -0 $(cat service.pid) 2>/dev/null; then echo alive; else echo reaped; fi > order.txt"
 jobs:
   - name: finite
@@ -231,7 +232,7 @@ jobs:
                 ),
             ] {
                 let root = scratch(label);
-                let config = format!("on:\n  close: \"{close}\"\n{IDLE}");
+                let config = format!("hooks:\n  close: \"{close}\"\n{IDLE}");
                 let child = spawn(&root, &config, &env);
                 let mut cleanup = Cleanup::new(root.clone(), child);
                 wait_ready(&root);
@@ -252,7 +253,7 @@ jobs:
         setup::serialized(|| {
             let root = scratch("timeout-child");
             let config =
-                format!("on:\n  close: \"sleep 30 & echo $! > hook-child.pid; wait\"\n{IDLE}");
+                format!("hooks:\n  close: \"sleep 30 & echo $! > hook-child.pid; wait\"\n{IDLE}");
             let child = spawn(&root, &config, &[("FUNZZY_CANCEL_GRACE_MS", "500")]);
             let mut cleanup = Cleanup::new(root.clone(), child);
             wait_ready(&root);
@@ -276,7 +277,7 @@ jobs:
         setup::serialized(|| {
             let root = scratch("second-signal");
             let config = format!(
-                "on:\n  close: \"echo close >> close.log; trap '' TERM INT; sleep 30\"\n{IDLE}"
+                "hooks:\n  close: \"echo close >> close.log; trap '' TERM INT; sleep 30\"\n{IDLE}"
             );
             let child = spawn(&root, &config, &[("FUNZZY_CANCEL_GRACE_MS", "1000")]);
             let mut cleanup = Cleanup::new(root.clone(), child);
@@ -304,13 +305,13 @@ jobs:
         setup::serialized(|| {
             // Valid commit replaces future hook.
             let root = scratch("reload-valid");
-            let initial = format!("on:\n  close: \"echo old > old.txt\"\n{IDLE}");
+            let initial = format!("hooks:\n  close: \"echo old > old.txt\"\n{IDLE}");
             let child = spawn(&root, &initial, &[]);
             let mut cleanup = Cleanup::new(root.clone(), child);
             wait_ready(&root);
             fs::write(
                 root.join(".watch.yaml"),
-                format!("on:\n  close: \"echo new > new.txt\"\n{IDLE}"),
+                format!("hooks:\n  close: \"echo new > new.txt\"\n{IDLE}"),
             )
             .unwrap();
             wait_until(Duration::from_secs(20), "valid reload commit", || {
@@ -330,7 +331,7 @@ jobs:
             // Invalid candidate never replaces last committed hook; fatal
             // config exit stays nonzero and hook runs once.
             let root = scratch("reload-invalid");
-            let stable = format!("on:\n  close: \"echo stable >> stable.log\"\n{IDLE}");
+            let stable = format!("hooks:\n  close: \"echo stable >> stable.log\"\n{IDLE}");
             let child = spawn(&root, &stable, &[]);
             let mut cleanup = Cleanup::new(root.clone(), child);
             wait_ready(&root);
@@ -362,7 +363,7 @@ jobs:
             cleanup.finish();
 
             let root = scratch("finite");
-            let config = "on:\n  close: \"echo forbidden > close.txt\"\njobs:\n  - name: once\n    run: echo once\n    change: '**/*'\n";
+            let config = "hooks:\n  close: \"echo forbidden > close.txt\"\njobs:\n  - name: once\n    run: echo once\n    change: '**/*'\n";
             fs::write(root.join(".watch.yaml"), config).unwrap();
             for args in [vec!["run", "once"], vec!["check"]] {
                 let status = Command::new(env!("CARGO_BIN_EXE_fzz"))
@@ -382,7 +383,7 @@ jobs:
     fn close_written_file_cannot_schedule_another_generation() {
         setup::serialized(|| {
             let root = scratch("no-feedback");
-            let config = "on:\n  close: \"echo close > close-trigger.txt\"\njobs:\n  - name: feedback\n    run: \"echo generation >> generations.log\"\n    change: '**/*.txt'\n";
+            let config = "hooks:\n  close: \"echo close > close-trigger.txt\"\njobs:\n  - name: feedback\n    run: \"echo generation >> generations.log\"\n    change: '**/*.txt'\n";
             let child = spawn(&root, config, &[]);
             let mut cleanup = Cleanup::new(root.clone(), child);
             wait_ready(&root);
@@ -408,7 +409,10 @@ jobs:
                 .unwrap();
             assert!(schema.status.success());
             let json: Value = serde_json::from_slice(&schema.stdout).unwrap();
-            assert_eq!(json["$defs"]["on"]["properties"]["close"]["type"], "string");
+            assert_eq!(
+                json["$defs"]["hooks"]["properties"]["close"]["type"],
+                "string"
+            );
 
             let init = Command::new(env!("CARGO_BIN_EXE_fzz"))
                 .current_dir(&root)
@@ -420,9 +424,9 @@ jobs:
             assert!(generated.contains("# close:"));
 
             for invalid in [
-                "on:\n  close: [a, b]\njobs:\n  - name: a\n    run: echo a\n    change: '**/*'\n",
-                "on:\n  close: ''\njobs:\n  - name: a\n    run: echo a\n    change: '**/*'\n",
-                "on:\n  close: 'echo {{filepath}}'\njobs:\n  - name: a\n    run: echo a\n    change: '**/*'\n",
+                "hooks:\n  close: [a, b]\njobs:\n  - name: a\n    run: echo a\n    change: '**/*'\n",
+                "hooks:\n  close: ''\njobs:\n  - name: a\n    run: echo a\n    change: '**/*'\n",
+                "hooks:\n  close: 'echo {{filepath}}'\njobs:\n  - name: a\n    run: echo a\n    change: '**/*'\n",
             ] {
                 fs::write(root.join(".watch.yaml"), invalid).unwrap();
                 let status = Command::new(env!("CARGO_BIN_EXE_fzz"))

--- a/tests/config_reload_lifecycle.rs
+++ b/tests/config_reload_lifecycle.rs
@@ -463,12 +463,12 @@ fn reload_adds_missing_future_root_and_observes_later_create() {
 /// committed hooks run at the run boundary.
 #[test]
 fn policy_surface_change_preserves_process_and_applies_hooks() {
-    let config = "on:\n  socket: sock\n  concurrency: 1\n  debounce: 500ms\njobs:\n  - name: build\n    run: 'echo build > build-verdict.txt'\n    change: 'src/**'\n";
+    let config = "on:\n  socket: sock\n  debounce: 500ms\nexecution:\n  concurrency: 1\njobs:\n  - name: build\n    run: 'echo build > build-verdict.txt'\n    change: 'src/**'\n";
     let directory = setup_directory("policy", config);
     let mut watcher = start_watcher(&directory);
     wait_until_socket(&directory);
 
-    let changed = "on:\n  socket: sock\n  concurrency: 4\n  debounce: 300ms\n  success: 'echo hooked > hook-verdict.txt'\njobs:\n  - name: build\n    run: 'echo build > build-verdict.txt'\n    change: 'src/**'\n";
+    let changed = "on:\n  socket: sock\n  debounce: 300ms\nexecution:\n  concurrency: 4\nhooks:\n  success: 'echo hooked > hook-verdict.txt'\njobs:\n  - name: build\n    run: 'echo build > build-verdict.txt'\n    change: 'src/**'\n";
     std::fs::write(directory.join(".watch.yaml"), changed).unwrap();
     wait_for_log(&directory, "hot-reloading to revision 2");
     assert!(

--- a/tests/future_files.rs
+++ b/tests/future_files.rs
@@ -17,6 +17,7 @@ use std::time::Duration;
 struct TestProcess {
     child: Child,
     directory: std::path::PathBuf,
+    child_log: std::path::PathBuf,
 }
 
 impl Drop for TestProcess {
@@ -24,6 +25,7 @@ impl Drop for TestProcess {
         let _ = self.child.kill();
         let _ = self.child.wait();
         let _ = std::fs::remove_dir_all(&self.directory);
+        let _ = std::fs::remove_file(&self.child_log);
     }
 }
 
@@ -39,8 +41,14 @@ fn setup_directory(test_name: &str, config: &str) -> std::path::PathBuf {
     std::fs::canonicalize(&directory).expect("canonicalize fixture root")
 }
 
+fn child_log_path(directory: &std::path::Path) -> std::path::PathBuf {
+    let fixture_name = directory.file_name().unwrap().to_string_lossy();
+    directory.with_file_name(format!("{fixture_name}.child.err"))
+}
+
 fn start_watcher(directory: &std::path::Path) -> TestProcess {
-    let child_log = std::fs::File::create(directory.join("child.err")).unwrap();
+    let child_log_path = child_log_path(directory);
+    let child_log = std::fs::File::create(&child_log_path).unwrap();
     let child = Command::new(env!("CARGO_BIN_EXE_fzz"))
         // Verbose: typed diagnostics (batches, matches, scheduling) land in
         // child.err so CI failures can be diagnosed from the logs alone.
@@ -55,6 +63,7 @@ fn start_watcher(directory: &std::path::Path) -> TestProcess {
     TestProcess {
         child,
         directory: directory.to_path_buf(),
+        child_log: child_log_path,
     }
 }
 
@@ -101,7 +110,7 @@ fn wait_until_or_dump(
         std::thread::sleep(Duration::from_millis(100));
     }
     eprintln!("--- watcher child.err (verbose) ---");
-    match std::fs::read_to_string(directory.join("child.err")) {
+    match std::fs::read_to_string(child_log_path(directory)) {
         Ok(log) => eprintln!("{log}"),
         Err(e) => eprintln!("<unreadable: {e}>",),
     }
@@ -387,6 +396,7 @@ fn burst_in_one_window_is_one_generation_then_next_window_is_next() {
 const PARALLEL_CONFIG: &str = r#"
 on:
   socket: sock
+execution:
   concurrency: 4
 jobs:
   - name: a
@@ -516,6 +526,7 @@ fn control_output_and_await_stay_exact_for_created_generation() {
 const BUSY_CONFIG: &str = r#"
 on:
   socket: sock
+execution:
   concurrency: 2
 jobs:
   - name: long


### PR DESCRIPTION
## Summary

- retarget push and pull-request workflows from `master` to `main`
- update branch-aware Nix scripts, installer source, and documentation links
- cover the installer default-version lookup with a deterministic regression test
- align integration fixtures with V2 `execution:`/`hooks:` ownership exposed by the restored `main` CI
- keep future-file watcher logs outside watched fixture roots to prevent self-generated events

## Testing

- `scripts/linux-install-test` (5 passed)
- Funzzy watcher `format` target (passed)
- Funzzy watcher `unit tests` target (passed)
- Funzzy watcher full `integration` target (passed in 339s)
- focused suites: `agent_loop` (12), `close_hook_lifecycle` (9), `config_reload_lifecycle` policy test (1), `future_files` (11)
- `bash -n linux-install.sh scripts/bump-nix-nightly scripts/linux-install-test`
