### PR TITLE
fix(test): define PTY lock file truncation

### DIFF
--- a/tests/recovery_pty.rs
+++ b/tests/recovery_pty.rs
@@ -44,6 +44,7 @@ fn acquire_pty_guard() -> PtyGuard {
     let path = std::env::temp_dir().join("funzzy-recovery-pty-global.lock");
     let lock_file = OpenOptions::new()
         .create(true)
+        .truncate(false)
         .read(true)
         .write(true)
         .open(path)


### PR DESCRIPTION
## Problem
Rust 1.97 Clippy rejects the recovery PTY lock file because `OpenOptions::create(true)` leaves truncation behavior implicit. This broke main run 32691687812.

## Fix
Explicitly preserve the persistent lock file with `.truncate(false)`.

## Verification
- Funzzy watcher: format and unit tests passed (generation 98)
- Local Clippy unavailable in the dev shell; the PR CI exercises the exact Rust 1.97 Clippy gate.