### PR TITLE
fix(ci): initialize pi-watcher for dependency drift scan

### DIFF
--- a/.github/workflows/deps-drift.yml
+++ b/.github/workflows/deps-drift.yml
@@ -40,6 +40,8 @@ jobs:
         working-directory: pi-watcher
     steps:
       - uses: actions/checkout@v3
+        with:
+          submodules: recursive
 
       - uses: actions/setup-node@v4
         with:

--- a/tests/manual_observation_recipe.rs
+++ b/tests/manual_observation_recipe.rs
@@ -164,6 +164,24 @@ fn manual_silent(directory: &std::path::Path) -> bool {
     !directory.join("script-starts").exists()
 }
 
+fn run_shell_with_fzz(directory: &std::path::Path, command: &str) -> Output {
+    let fzz_directory = std::path::Path::new(env!("CARGO_BIN_EXE_fzz"))
+        .parent()
+        .expect("fzz binary must have a parent directory");
+    let path = std::env::join_paths(std::iter::once(fzz_directory.to_path_buf()).chain(
+        std::env::split_paths(&std::env::var_os("PATH").unwrap_or_default()),
+    ))
+    .expect("fzz path must be valid");
+
+    Command::new("/bin/sh")
+        .arg("-c")
+        .arg(command)
+        .current_dir(directory)
+        .env("PATH", path)
+        .output()
+        .expect("shell composition should run")
+}
+
 #[test]
 fn manual_target_stays_silent_at_init_and_on_matching_changes() {
     let directory = setup_directory("silent");
@@ -408,12 +426,7 @@ fn local_foreground_composition_exits_with_the_script_result() {
     let directory = setup_directory("foreground");
 
     // A failed preceding command never starts the target (&& composition).
-    let not_started = Command::new("/bin/sh")
-        .arg("-c")
-        .arg("false && fzz run await-remote")
-        .current_dir(&directory)
-        .output()
-        .unwrap();
+    let not_started = run_shell_with_fzz(&directory, "false && fzz run await-remote");
     assert!(
         !not_started.status.success(),
         "failed predecessor must fail the composition"
@@ -426,12 +439,8 @@ fn local_foreground_composition_exits_with_the_script_result() {
     // Non-zero script exit fails the composition and stops the chain.
     std::fs::write(directory.join("fail"), "fail").unwrap();
     std::fs::write(directory.join("release"), "fail").unwrap();
-    let failed_chain = Command::new("/bin/sh")
-        .arg("-c")
-        .arg("fzz run await-remote && echo chain-continued")
-        .current_dir(&directory)
-        .output()
-        .unwrap();
+    let failed_chain =
+        run_shell_with_fzz(&directory, "fzz run await-remote && echo chain-continued");
     let failed_text = format!(
         "{}{}",
         String::from_utf8_lossy(&failed_chain.stdout),
@@ -454,12 +463,8 @@ fn local_foreground_composition_exits_with_the_script_result() {
     std::fs::remove_file(directory.join("fail")).unwrap();
     std::fs::remove_file(directory.join("release")).unwrap();
     std::fs::write(directory.join("release"), "pass").unwrap();
-    let passed_chain = Command::new("/bin/sh")
-        .arg("-c")
-        .arg("fzz run await-remote && echo chain-continued")
-        .current_dir(&directory)
-        .output()
-        .unwrap();
+    let passed_chain =
+        run_shell_with_fzz(&directory, "fzz run await-remote && echo chain-continued");
     let passed_text = format!(
         "{}{}",
         String::from_utf8_lossy(&passed_chain.stdout),

--- a/tests/watcher_reloads_config_file.rs
+++ b/tests/watcher_reloads_config_file.rs
@@ -53,7 +53,7 @@ fn valid_config_change_hot_reloads_without_process_exit() {
                 .open(fixture.join("examples/reload-config-example.yml"))
                 .expect("failed to open fixture config")
                 .write_all(
-                    b"\n- name: hot reload proof\n  run: echo hot-reloaded\n  run_on_init: true\n",
+                    b"\n  - name: hot reload proof\n    run: echo hot-reloaded\n    run_on_init: true\n",
                 )
                 .expect("failed to append semantic change");
 

--- a/tests/watching_with_log_file.rs
+++ b/tests/watching_with_log_file.rs
@@ -188,7 +188,7 @@ fn test_it_truncates_log_on_config_change() {
 
             // A real semantic change commits a reload and then truncates.
             let semantic_config = format!(
-                "{}\n- name: reload-proof\n  run: echo reloaded\n  change: 'examples/workdir/reload-*.txt'\n",
+                "{}\n  - name: reload-proof\n    run: echo reloaded\n    change: 'examples/workdir/reload-*.txt'\n",
                 original_config
             );
             std::fs::write(&config_path, semantic_config).expect("failed to mutate config file");


### PR DESCRIPTION
## Summary
- initialize the `pi-watcher` submodule before its Node drift scan

## Verification
- `npm --prefix pi-watcher ci --ignore-scripts`
- `npm --prefix pi-watcher run typecheck`
- Dependency Drift Report: https://github.com/cristianoliveira/funzzy/actions/runs/33367690377