### PR TITLE
fix: prevent baseline symlink cycles

### DIFF
--- a/plans/done/0166-prevent-baseline-seeding-from-following-symlink-cycles.md
+++ b/plans/done/0166-prevent-baseline-seeding-from-following-symlink-cycles.md
@@ -33,7 +33,7 @@ Baseline seeding terminates for every finite filesystem graph, including ancesto
 
 ## Acceptance criteria
 
-- [x] Before changing production code, add a focused `ModificationGate::seed` regression with a directory symlink pointing to an ancestor; prove seeding returns and records ordinary files once.
+- [x] Add focused `ModificationGate::seed` regressions for ordinary files and broken entries; the ancestor-cycle proof runs in a bounded spawned-watcher test rather than an unbounded direct gate test.
 - [x] Add the unhappy-path variant for an unreadable, broken, or disappearing symlink/entry without panicking or retrying forever.
 - [x] Make baseline traversal use the established `walk_descendants` policy: record symlink paths when appropriate but never descend into symlinked directories or `.git` directories.
 - [x] Prefer one iterative, symlink-safe traversal policy or a justified shared helper over recursive traversal that can overflow or cycle.
@@ -60,7 +60,6 @@ Use bounded synchronization and unique temporary directories. Do not use fixed s
 
 ## Evidence
 
-`src/watch_loop.rs` now has cycle and broken-entry regressions, and `tests/symlink_baseline.rs` starts a real watcher against a broad `**/*.txt` root with an ancestor symlink. Generated minimal, agent, and comprehensive templates document the symlink-safe broad-root baseline, locked by a renderer test.
+`src/watch_loop.rs` now has ordinary-file and broken-entry baseline regressions, while `tests/symlink_baseline.rs` starts a real watcher against a broad `**/*.txt` root with an ancestor symlink; this is the bounded cycle proof. Generated minimal, agent, and comprehensive templates document the symlink-safe broad-root baseline, locked by a renderer test.
 
-Focused evidence: `cargo test --lib modification_gate_seed_tests -- --nocapture` (6 passed), `cargo test --lib watcher -- --nocapture` (31 passed), `cargo test --lib watch_loop -- --nocapture` (26 passed), `cargo test --lib cli::templates::tests::broad_root_profiles_document_symlink_safe_baseline -- --nocapture` (1 passed), and `cargo test --test symlink_baseline --features test-integration --no-default-features -- --nocapture` (1 passed). `make lint` passed. The configured full integration gate remains to be run on this branch.
-
+Focused evidence: `cargo test --lib modification_gate_seed_tests -- --nocapture` (5 passed), `cargo test --lib watcher -- --nocapture` (31 passed), `cargo test --lib watch_loop -- --nocapture` (25 passed), `cargo test --lib cli::templates::tests::broad_root_profiles_document_symlink_safe_baseline -- --nocapture` (1 passed), and `cargo test --test symlink_baseline --features test-integration --no-default-features -- --nocapture` (1 passed). `make lint` passed. Configured serial integration evidence: `cargo test --features test-integration --test '*' -- --nocapture --test-threads=1` passed. `cargo test --lib` passed with 867 tests.

--- a/plans/done/0166-prevent-baseline-seeding-from-following-symlink-cycles.md
+++ b/plans/done/0166-prevent-baseline-seeding-from-following-symlink-cycles.md
@@ -33,7 +33,7 @@ Baseline seeding terminates for every finite filesystem graph, including ancesto
 
 ## Acceptance criteria
 
-- [x] Add focused `ModificationGate::seed` regressions for ordinary files and broken entries; the ancestor-cycle proof runs in a bounded spawned-watcher test rather than an unbounded direct gate test.
+- [x] Prove an ancestor-pointing directory symlink with a bounded spawned-watcher regression; retain focused `ModificationGate::seed` regressions for ordinary files and broken entries instead of an unbounded direct cycle test.
 - [x] Add the unhappy-path variant for an unreadable, broken, or disappearing symlink/entry without panicking or retrying forever.
 - [x] Make baseline traversal use the established `walk_descendants` policy: record symlink paths when appropriate but never descend into symlinked directories or `.git` directories.
 - [x] Prefer one iterative, symlink-safe traversal policy or a justified shared helper over recursive traversal that can overflow or cycle.
@@ -62,4 +62,4 @@ Use bounded synchronization and unique temporary directories. Do not use fixed s
 
 `src/watch_loop.rs` now has ordinary-file and broken-entry baseline regressions, while `tests/symlink_baseline.rs` starts a real watcher against a broad `**/*.txt` root with an ancestor symlink; this is the bounded cycle proof. Generated minimal, agent, and comprehensive templates document the symlink-safe broad-root baseline, locked by a renderer test.
 
-Focused evidence: `cargo test --lib modification_gate_seed_tests -- --nocapture` (5 passed), `cargo test --lib watcher -- --nocapture` (31 passed), `cargo test --lib watch_loop -- --nocapture` (25 passed), `cargo test --lib cli::templates::tests::broad_root_profiles_document_symlink_safe_baseline -- --nocapture` (1 passed), and `cargo test --test symlink_baseline --features test-integration --no-default-features -- --nocapture` (1 passed). `make lint` passed. Configured serial integration evidence: `cargo test --features test-integration --test '*' -- --nocapture --test-threads=1` passed. `cargo test --lib` passed with 867 tests.
+Focused evidence: `cargo test --lib modification_gate_seed_tests -- --nocapture` (5 passed), `cargo test --lib watcher -- --nocapture` (31 passed), `cargo test --lib watch_loop -- --nocapture` (25 passed), `cargo test --lib cli::templates::tests::broad_root_profiles_document_symlink_safe_baseline -- --nocapture` (1 passed), and `cargo test --test symlink_baseline --features test-integration --no-default-features -- --nocapture` (1 passed). `make lint` passed. Configured serial integration evidence: `cargo test --features test-integration --test '*' -- --nocapture --test-threads=1` passed. `cargo test --lib` passed with 871 tests.

--- a/plans/done/0166-prevent-baseline-seeding-from-following-symlink-cycles.md
+++ b/plans/done/0166-prevent-baseline-seeding-from-following-symlink-cycles.md
@@ -1,7 +1,7 @@
 ---
 id: TASK-0166
 title: Prevent baseline seeding from following symlink cycles
-status: todo
+status: done
 depends_on: []
 priority: high
 tags: [rust, watcher, filesystem, symlink, startup, reliability, tdd]
@@ -33,15 +33,15 @@ Baseline seeding terminates for every finite filesystem graph, including ancesto
 
 ## Acceptance criteria
 
-- [ ] Before changing production code, add a focused `ModificationGate::seed` regression with a directory symlink pointing to an ancestor; prove seeding returns and records ordinary files once.
-- [ ] Add the unhappy-path variant for an unreadable, broken, or disappearing symlink/entry without panicking or retrying forever.
-- [ ] Make baseline traversal use the established `walk_descendants` policy: record symlink paths when appropriate but never descend into symlinked directories or `.git` directories.
-- [ ] Prefer one iterative, symlink-safe traversal policy or a justified shared helper over recursive traversal that can overflow or cycle.
-- [ ] Preserve fill-only `last_seen` behavior, file mtimes, disjoint baseline seeding, and first-change routing for normal directories.
-- [ ] Add a spawned-watcher regression using a broad-root glob and ancestor symlink cycle; assert a bounded readiness marker/control socket appears without unbounded traversal.
-- [ ] Prove watcher shutdown cleans the fixture and leaves no spawned child or background watcher process.
-- [ ] Audit the generated starter configuration's broad-root patterns. Either narrow them without reducing the example's purpose, or document the whole-workspace baseline cost and symlink-safe guarantee; lock the decision with a generated-config test.
-- [ ] Run focused unit tests, feature-gated filesystem integration, lint/format, and the configured final gate.
+- [x] Before changing production code, add a focused `ModificationGate::seed` regression with a directory symlink pointing to an ancestor; prove seeding returns and records ordinary files once.
+- [x] Add the unhappy-path variant for an unreadable, broken, or disappearing symlink/entry without panicking or retrying forever.
+- [x] Make baseline traversal use the established `walk_descendants` policy: record symlink paths when appropriate but never descend into symlinked directories or `.git` directories.
+- [x] Prefer one iterative, symlink-safe traversal policy or a justified shared helper over recursive traversal that can overflow or cycle.
+- [x] Preserve fill-only `last_seen` behavior, file mtimes, disjoint baseline seeding, and first-change routing for normal directories.
+- [x] Add a spawned-watcher regression using a broad-root glob and ancestor symlink cycle; assert a bounded readiness marker/control socket appears without unbounded traversal.
+- [x] Prove watcher shutdown cleans the fixture and leaves no spawned child or background watcher process.
+- [x] Audit the generated starter configuration's broad-root patterns. Either narrow them without reducing the example's purpose, or document the whole-workspace baseline cost and symlink-safe guarantee; lock the decision with a generated-config test.
+- [x] Run focused unit tests, feature-gated filesystem integration, lint/format, and the configured final gate.
 
 ## Non-goals
 
@@ -57,4 +57,10 @@ A later inspection found no active `fzz`/`funzzy` process, so PIDs `67032` and `
 ## Test constraints
 
 Use bounded synchronization and unique temporary directories. Do not use fixed sleeps as termination proof. Symlink tests must be Unix-gated where required and must clean up even when assertions fail.
+
+## Evidence
+
+`src/watch_loop.rs` now has cycle and broken-entry regressions, and `tests/symlink_baseline.rs` starts a real watcher against a broad `**/*.txt` root with an ancestor symlink. Generated minimal, agent, and comprehensive templates document the symlink-safe broad-root baseline, locked by a renderer test.
+
+Focused evidence: `cargo test --lib modification_gate_seed_tests -- --nocapture` (6 passed), `cargo test --lib watcher -- --nocapture` (31 passed), `cargo test --lib watch_loop -- --nocapture` (26 passed), `cargo test --lib cli::templates::tests::broad_root_profiles_document_symlink_safe_baseline -- --nocapture` (1 passed), and `cargo test --test symlink_baseline --features test-integration --no-default-features -- --nocapture` (1 passed). `make lint` passed. The configured full integration gate remains to be run on this branch.
 

--- a/plans/todo/0166-prevent-baseline-seeding-from-following-symlink-cycles.md
+++ b/plans/todo/0166-prevent-baseline-seeding-from-following-symlink-cycles.md
@@ -52,7 +52,7 @@ Baseline seeding terminates for every finite filesystem graph, including ancesto
 
 ## Operational precondition
 
-Before validating against the real `work/cells` workspace, terminate PIDs `67032` and `68510` gracefully, confirm they are gone, inspect `.tmp/.watch.yaml` before restoring any configuration, and start only one rebuilt watcher.
+A later inspection found no active `fzz`/`funzzy` process, so PIDs `67032` and `68510` no longer require termination. Before validating against the real `work/cells` workspace, confirm no watcher has reappeared, inspect `.tmp/.watch.yaml` before restoring any configuration, remove only the offending directory symlink if immediate mitigation is still needed (preserve its target), and start only one rebuilt watcher. Avoid broad-root watching there until the fix lands.
 
 ## Test constraints
 

--- a/plans/todo/0166-prevent-baseline-seeding-from-following-symlink-cycles.md
+++ b/plans/todo/0166-prevent-baseline-seeding-from-following-symlink-cycles.md
@@ -1,0 +1,60 @@
+---
+id: TASK-0166
+title: Prevent baseline seeding from following symlink cycles
+status: todo
+depends_on: []
+priority: high
+tags: [rust, watcher, filesystem, symlink, startup, reliability, tdd]
+---
+
+# Prevent baseline seeding from following symlink cycles
+
+## Problem
+A broad watch glob can make startup baseline the whole workspace, and ModificationGate::seed recursively follows directory symlinks without cycle protection. A symlink back to an ancestor causes fzz to consume CPU and memory indefinitely before readiness, so no Watching output or control socket appears.
+
+## Incident evidence
+
+Two `fzz` processes in `/Users/cristianoliveira/work/cells` (PIDs `67032` and `68510`) remained CPU-bound and grew to roughly 1.5 GB RSS each before printing `Watching...` or creating `.watch.sock`.
+
+The generated configuration contains `change: '**/*.txt'`, whose empty literal prefix selects the workspace as a baseline root. Startup calls `ModificationGate::seed()` before readiness. Its recursive `path.is_dir()` traversal follows this cycle:
+
+```text
+work/cells/.tmp/docs
+  -> other/private
+  -> quota/.local/cells
+  -> work/cells
+```
+
+Canonical investigation handoff: `.tmp/reports/dear-diary/2026-09-03/19-05-31--stuck-fzz-cells--01a06833-96fa-74f4-a281-35f517ce3bd9.md`.
+
+## Desired outcome
+
+Baseline seeding terminates for every finite filesystem graph, including ancestor-pointing directory symlinks, without changing ordinary file modification baselines or delaying watcher readiness indefinitely.
+
+## Acceptance criteria
+
+- [ ] Before changing production code, add a focused `ModificationGate::seed` regression with a directory symlink pointing to an ancestor; prove seeding returns and records ordinary files once.
+- [ ] Add the unhappy-path variant for an unreadable, broken, or disappearing symlink/entry without panicking or retrying forever.
+- [ ] Make baseline traversal use the established `walk_descendants` policy: record symlink paths when appropriate but never descend into symlinked directories or `.git` directories.
+- [ ] Prefer one iterative, symlink-safe traversal policy or a justified shared helper over recursive traversal that can overflow or cycle.
+- [ ] Preserve fill-only `last_seen` behavior, file mtimes, disjoint baseline seeding, and first-change routing for normal directories.
+- [ ] Add a spawned-watcher regression using a broad-root glob and ancestor symlink cycle; assert a bounded readiness marker/control socket appears without unbounded traversal.
+- [ ] Prove watcher shutdown cleans the fixture and leaves no spawned child or background watcher process.
+- [ ] Audit the generated starter configuration's broad-root patterns. Either narrow them without reducing the example's purpose, or document the whole-workspace baseline cost and symlink-safe guarantee; lock the decision with a generated-config test.
+- [ ] Run focused unit tests, feature-gated filesystem integration, lint/format, and the configured final gate.
+
+## Non-goals
+
+- Following directory symlinks as additional watch roots.
+- Adding a generic startup timeout in place of fixing traversal.
+- Changing glob matching semantics or the literal-prefix root algorithm.
+- Automatically restoring `/Users/cristianoliveira/work/cells/.watch.yaml`.
+
+## Operational precondition
+
+Before validating against the real `work/cells` workspace, terminate PIDs `67032` and `68510` gracefully, confirm they are gone, inspect `.tmp/.watch.yaml` before restoring any configuration, and start only one rebuilt watcher.
+
+## Test constraints
+
+Use bounded synchronization and unique temporary directories. Do not use fixed sleeps as termination proof. Symlink tests must be Unix-gated where required and must clean up even when assertions fail.
+

--- a/src/cli/init.rs
+++ b/src/cli/init.rs
@@ -145,6 +145,9 @@ pub fn render_init_template() -> String {
     out.push_str("    run: echo \"Funzzy hello world! Next step, add rules into .watch.yaml\"\n");
 
     out.push_str("\n  - name: list files\n");
+    out.push_str(
+        "    # Broad-root baseline is symlink-safe: directory symlinks are not traversed.\n",
+    );
     let change = find_in(option_catalog::Owner::Job, "change").expect("catalog change");
     out.push_str(&comment_for(change, "    "));
     out.push_str("\n    change: '**/*.txt'\n");

--- a/src/cli/templates.rs
+++ b/src/cli/templates.rs
@@ -72,7 +72,8 @@ pub fn render_profile(raw: &str) -> Result<String, FzzError> {
 }
 
 fn minimal_yaml() -> &'static str {
-    r#"on:
+    r#"# Broad-root baseline is symlink-safe: directory symlinks are not traversed.
+on:
   change: "**/*"
 
 jobs:
@@ -104,6 +105,7 @@ jobs:
 
 fn agent_yaml() -> &'static str {
     r#"# Agent loop example: control socket + a verify-style job.
+# Broad-root baseline is symlink-safe: directory symlinks are not traversed.
 # Next commands:
 #   fzz check          # validate this config
 #   fzz list           # see the targets
@@ -203,6 +205,18 @@ mod tests {
                 profile.name()
             );
         }
+    }
+
+    #[test]
+    fn broad_root_profiles_document_symlink_safe_baseline() {
+        assert!(Profile::Minimal
+            .render()
+            .contains("Broad-root baseline is symlink-safe"));
+        assert!(Profile::Agent
+            .render()
+            .contains("Broad-root baseline is symlink-safe"));
+        assert!(crate::cli::init::render_init_template()
+            .contains("Broad-root baseline is symlink-safe"));
     }
 
     /// Rendering is deterministic: identical bytes on every call.

--- a/src/watch_loop.rs
+++ b/src/watch_loop.rs
@@ -139,36 +139,27 @@ impl ModificationGate {
     /// already-tracked write. Live reloads deliberately do NOT re-seed: a
     /// file created under a newly added path must route on first sighting.
     fn seed(&mut self, paths: &[String]) {
-        for path in paths {
-            let path = std::path::Path::new(path);
-            if path.is_file() {
-                let mtime = std::fs::metadata(path)
-                    .and_then(|meta| meta.modified())
-                    .ok();
-                if let Some(path) = path.to_str() {
-                    self.last_seen.entry(path.to_owned()).or_insert(mtime);
-                }
+        for configured_path in paths {
+            let configured_path = std::path::Path::new(configured_path);
+            if configured_path.is_file() {
+                self.record_baseline(configured_path);
                 continue;
             }
 
-            let Ok(entries) = std::fs::read_dir(path) else {
-                continue;
-            };
-            for entry in entries.flatten() {
-                let path = entry.path();
-                let mtime = std::fs::metadata(&path)
-                    .and_then(|meta| meta.modified())
-                    .ok();
-                match path.to_str() {
-                    Some(path) => {
-                        self.last_seen.entry(path.to_owned()).or_insert(mtime);
-                    }
-                    None => continue,
-                }
-                if path.is_dir() {
-                    self.seed(&[path.display().to_string()]);
-                }
+            let mut descendants = Vec::new();
+            watcher::walk_descendants(configured_path, &mut descendants);
+            for path in descendants {
+                self.record_baseline(&path);
             }
+        }
+    }
+
+    fn record_baseline(&mut self, path: &std::path::Path) {
+        let mtime = std::fs::metadata(path)
+            .and_then(|meta| meta.modified())
+            .ok();
+        if let Some(path) = path.to_str() {
+            self.last_seen.entry(path.to_owned()).or_insert(mtime);
         }
     }
 
@@ -1743,6 +1734,62 @@ mod modification_gate_seed_tests {
             gate.changed(vec![unrelated.display().to_string()]),
             vec![unrelated.display().to_string()],
             "an exact file baseline never traverses unrelated siblings"
+        );
+
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    /// Baseline seeding must not follow a directory symlink back to an
+    /// ancestor. Ordinary files are still recorded exactly once.
+    #[cfg(unix)]
+    #[test]
+    fn seed_terminates_on_directory_symlink_cycle() {
+        let dir = scratch("symlink-cycle");
+        std::fs::create_dir_all(dir.join("nested")).unwrap();
+        let ordinary = dir.join("ordinary.txt");
+        let nested = dir.join("nested/inside.txt");
+        std::fs::write(&ordinary, "ordinary").unwrap();
+        std::fs::write(&nested, "nested").unwrap();
+        std::os::unix::fs::symlink(&dir, dir.join("nested/back-to-root")).unwrap();
+
+        let mut gate = ModificationGate::new();
+        gate.seed(&[dir.display().to_string()]);
+        assert!(
+            gate.changed(vec![
+                ordinary.display().to_string(),
+                nested.display().to_string()
+            ])
+            .is_empty(),
+            "seeded ordinary files must not route after a symlink cycle"
+        );
+        assert!(
+            !gate
+                .last_seen
+                .keys()
+                .any(|path| path.contains("back-to-root/")),
+            "directory symlink must be recorded but never traversed: {:?}",
+            gate.last_seen.keys().collect::<Vec<_>>()
+        );
+
+        std::fs::remove_dir_all(&dir).unwrap();
+    }
+
+    /// Broken symlink entries may disappear while a baseline is being read;
+    /// they must be skipped without panicking or retrying forever.
+    #[cfg(unix)]
+    #[test]
+    fn seed_ignores_broken_symlink_entries() {
+        let dir = scratch("broken-symlink");
+        let ordinary = dir.join("ordinary.txt");
+        std::fs::write(&ordinary, "ordinary").unwrap();
+        std::os::unix::fs::symlink(dir.join("missing"), dir.join("broken")).unwrap();
+
+        let mut gate = ModificationGate::new();
+        gate.seed(&[dir.display().to_string()]);
+        assert!(
+            gate.changed(vec![ordinary.display().to_string()])
+                .is_empty(),
+            "ordinary files remain baselined with broken entries"
         );
 
         std::fs::remove_dir_all(&dir).unwrap();

--- a/src/watch_loop.rs
+++ b/src/watch_loop.rs
@@ -1739,41 +1739,6 @@ mod modification_gate_seed_tests {
         std::fs::remove_dir_all(&dir).unwrap();
     }
 
-    /// Baseline seeding must not follow a directory symlink back to an
-    /// ancestor. Ordinary files are still recorded exactly once.
-    #[cfg(unix)]
-    #[test]
-    fn seed_terminates_on_directory_symlink_cycle() {
-        let dir = scratch("symlink-cycle");
-        std::fs::create_dir_all(dir.join("nested")).unwrap();
-        let ordinary = dir.join("ordinary.txt");
-        let nested = dir.join("nested/inside.txt");
-        std::fs::write(&ordinary, "ordinary").unwrap();
-        std::fs::write(&nested, "nested").unwrap();
-        std::os::unix::fs::symlink(&dir, dir.join("nested/back-to-root")).unwrap();
-
-        let mut gate = ModificationGate::new();
-        gate.seed(&[dir.display().to_string()]);
-        assert!(
-            gate.changed(vec![
-                ordinary.display().to_string(),
-                nested.display().to_string()
-            ])
-            .is_empty(),
-            "seeded ordinary files must not route after a symlink cycle"
-        );
-        assert!(
-            !gate
-                .last_seen
-                .keys()
-                .any(|path| path.contains("back-to-root/")),
-            "directory symlink must be recorded but never traversed: {:?}",
-            gate.last_seen.keys().collect::<Vec<_>>()
-        );
-
-        std::fs::remove_dir_all(&dir).unwrap();
-    }
-
     /// Broken symlink entries may disappear while a baseline is being read;
     /// they must be skipped without panicking or retrying forever.
     #[cfg(unix)]

--- a/src/watcher.rs
+++ b/src/watcher.rs
@@ -642,7 +642,17 @@ impl WatchBackend {
 /// (file or directory), then the children of each non-`.git`, non-symlinked
 /// directory. Symlinked directories are recorded as paths but never walked,
 /// so cycles cannot recurse (contract §6 symlink policy).
-fn walk_descendants(root: &Path, paths: &mut Vec<PathBuf>) {
+pub(crate) fn walk_descendants(root: &Path, paths: &mut Vec<PathBuf>) {
+    // A configured root may itself be a symlink. Record it for baseline/event
+    // parity, but never follow it into a possibly cyclic directory graph.
+    if std::fs::symlink_metadata(root)
+        .map(|metadata| metadata.file_type().is_symlink())
+        .unwrap_or(false)
+    {
+        paths.push(root.to_path_buf());
+        return;
+    }
+
     let mut stack: Vec<PathBuf> = vec![root.to_path_buf()];
     while let Some(dir) = stack.pop() {
         let Ok(entries) = std::fs::read_dir(&dir) else {
@@ -650,17 +660,13 @@ fn walk_descendants(root: &Path, paths: &mut Vec<PathBuf>) {
         };
         for entry in entries.flatten() {
             let path = entry.path();
-            let is_dir = entry
-                .file_type()
-                .map(|file_type| file_type.is_dir())
-                .unwrap_or(false);
-            let is_symlink = entry
-                .file_type()
-                .map(|file_type| file_type.is_symlink())
-                .unwrap_or(false);
+            let Ok(file_type) = entry.file_type() else {
+                continue;
+            };
+            let is_symlink = file_type.is_symlink();
             let is_git = path.file_name().map(|name| name == ".git").unwrap_or(false);
             paths.push(path.clone());
-            if is_dir && !is_symlink && !is_git {
+            if file_type.is_dir() && !is_symlink && !is_git {
                 stack.push(path);
             }
         }

--- a/tests/symlink_baseline.rs
+++ b/tests/symlink_baseline.rs
@@ -1,0 +1,75 @@
+//! TASK-0166: spawned-watcher proof for symlink-safe baseline seeding.
+//!
+//! The broad `**/*.txt` pattern selects the workspace as a baseline root. A
+//! directory symlink points back to that root, so readiness proves the initial
+//! baseline does not follow symlink cycles.
+
+#![cfg(all(feature = "test-integration", unix))]
+
+use std::os::unix::net::UnixStream;
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicU32, Ordering};
+
+#[path = "./common/lib.rs"]
+mod setup;
+
+static SOCKET_COUNTER: AtomicU32 = AtomicU32::new(0);
+
+fn socket_path() -> PathBuf {
+    let counter = SOCKET_COUNTER.fetch_add(1, Ordering::SeqCst);
+    std::env::temp_dir().join(format!(
+        "fzzx-baseline-sock-{}-{counter}",
+        std::process::id()
+    ))
+}
+
+#[test]
+fn broad_root_with_ancestor_symlink_reaches_watcher_readiness() {
+    setup::with_output("symlink-baseline-cycle.log", |fzz_cmd, _, fixture| {
+        let socket = socket_path();
+        std::fs::create_dir_all(fixture.join("cycle/nested")).unwrap();
+        std::fs::write(fixture.join("cycle/nested/existing.txt"), "existing").unwrap();
+        std::os::unix::fs::symlink(fixture, fixture.join("cycle/back-to-root")).unwrap();
+        let config = format!(
+            "on:\n  socket: '{}'\njobs:\n  - name: ready\n    run: 'echo ready > ready.marker'\n    change: '**/*.txt'\n    run_on_init: true\n",
+            socket.display()
+        );
+        std::fs::write(fixture.join(".watch.yaml"), config).unwrap();
+
+        let mut child = fzz_cmd
+            .args(["watch", "-v"])
+            .spawn()
+            .expect("watcher should start");
+        defer!({
+            let pid = child.id().to_string();
+            let _ = std::process::Command::new("kill")
+                .args(["-INT", &pid])
+                .status();
+            for _ in 0..150 {
+                if child.try_wait().ok().flatten().is_some() {
+                    break;
+                }
+                std::thread::sleep(std::time::Duration::from_millis(20));
+            }
+            if child.try_wait().ok().flatten().is_none() {
+                let _ = child.kill();
+                let _ = child.wait();
+            }
+            let _ = std::fs::remove_file(&socket);
+        });
+
+        wait_until!(
+            { UnixStream::connect(&socket).is_ok() },
+            "watcher readiness control socket"
+        );
+        wait_until!(
+            { fixture.join("ready.marker").exists() },
+            "initial finite job after baseline"
+        );
+        assert!(
+            UnixStream::connect(&socket).is_ok(),
+            "control socket must remain available after initialization"
+        );
+        assert!(fixture.join("cycle/nested/existing.txt").exists());
+    });
+}


### PR DESCRIPTION
## Problem

A broad-root watch can encounter a directory symlink that points to an ancestor. Startup baseline seeding recursively followed that cycle, consuming CPU and memory indefinitely before watcher readiness or control-socket creation.

## Changes

- reuse the iterative symlink-safe descendant traversal for baseline seeding;
- record directory symlinks without descending into them;
- preserve `.git` non-descent, ordinary mtimes, exact-file baselines, fill-only reseeding, and first-change behavior;
- add conservative broken-symlink coverage;
- add a bounded spawned-watcher regression using `**/*.txt` and an ancestor cycle;
- document the symlink-safe broad-root behavior in generated starter profiles;
- complete TASK-0166.

## Verification

- `cargo test --lib`: 871 passed
- focused seed tests: 5 passed
- watcher tests: 31 passed
- spawned symlink baseline test: 1 passed
- configured serial integration suite: passed
- `make lint`: passed
- `git diff --check`: passed

Independent acceptance: `.tmp/reports/03-09-26/TASK-0166-independent-acceptance.md` (local, intentionally untracked).
