### PR TITLE
docs: make README a concise project overview

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,50 @@
+# Contributing to Funzzy
+
+Contributions, bug reports, and feature proposals are welcome.
+
+## Setup
+
+Funzzy requires Rust and Cargo. The minimum supported version is declared by `rust-version` in `Cargo.toml`.
+
+```bash
+git clone https://github.com/cristianoliveira/funzzy.git
+cd funzzy
+cargo build
+```
+
+Nix users can enter the repository development shell instead.
+
+## Checks
+
+Use focused tests while changing code, then run the relevant gates:
+
+```bash
+cargo test <focused-test>
+make lint
+make tests
+make integration       # CLI, watcher, process, config, or socket behavior
+```
+
+`make integration-e2e` is reserved for changes that require real filesystem end-to-end coverage.
+
+When `.watch.yaml` is active, the configured `@agent-final` target is the final project gate.
+
+## Code style
+
+- Format Rust with `cargo fmt`.
+- Keep Clippy warning-free.
+- Add deterministic tests for happy and failure paths.
+- Use bounded polling instead of fixed sleeps in filesystem/process tests.
+- Preserve public CLI, configuration, and control-socket compatibility unless the change explicitly defines a breaking contract.
+
+See `AGENTS.md` and the nearest nested `AGENTS.md` for module-specific guidance.
+
+## Pull requests
+
+1. Create a focused branch.
+2. Add tests before changing behavior.
+3. Run the relevant checks.
+4. Explain the problem, behavior change, verification, and compatibility impact.
+5. Open a pull request against `main`.
+
+Keep unrelated formatting, dependency, submodule, and generated-file changes out of the pull request.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Contributions, bug reports, and feature proposals are welcome.
 
 ## Setup
 
-Funzzy requires Rust and Cargo. The minimum supported version is declared by `rust-version` in `Cargo.toml`.
+Funzzy requires Rust and Cargo. The `rust-version` value in `Cargo.toml` specifies the minimum Rust version.
 
 ```bash
 git clone https://github.com/cristianoliveira/funzzy.git
@@ -16,7 +16,7 @@ Nix users can enter the repository development shell instead.
 
 ## Checks
 
-Use focused tests while changing code, then run the relevant gates:
+Run focused tests while you change code. Then run the applicable gates:
 
 ```bash
 cargo test <focused-test>
@@ -25,7 +25,7 @@ make tests
 make integration       # CLI, watcher, process, config, or socket behavior
 ```
 
-`make integration-e2e` is reserved for changes that require real filesystem end-to-end coverage.
+Use `make integration-e2e` only when a change requires a real file-system test.
 
 When `.watch.yaml` is active, the configured `@agent-final` target is the final project gate.
 

--- a/README.md
+++ b/README.md
@@ -7,18 +7,18 @@
 
 **One reliable edit loop for developers and coding agents.**
 
-Funzzy is a fast Rust file watcher and local workflow runner. Define checks once, run them when files change, and inspect the exact result without scraping logs or trusting stale green output.
+Funzzy is a fast Rust file watcher and local workflow runner. You define checks in one YAML file. Funzzy runs matching jobs when files change. It reports the state of each run, so you do not have to inspect logs or reuse an old result.
 
 ```text
-edit -> match changed paths -> run configured jobs -> inspect fresh result -> repeat
+edit -> match changed files -> run jobs -> inspect result -> repeat
 ```
 
 ## Why Funzzy?
 
-- **One workflow:** use the same YAML for watching, one-shot local runs, editors, CI, and agents.
-- **Predictable execution:** declaration order, explicit parallel groups, debounced generations, cancellation, and process-tree cleanup.
-- **Useful long-running services:** readiness-enabled services can stay alive after their startup generation settles.
-- **Exact feedback:** a local control socket exposes current status, generation identity, bounded output, and cancellation.
+- **One workflow:** use the same YAML file for watch mode, local runs, editors, CI, and agents.
+- **Predictable execution:** Funzzy runs jobs in declared order. Named groups enable parallel work. Cancellation stops the complete process tree.
+- **Long-running services:** a readiness check confirms that a service started correctly. The service can then stay active.
+- **Exact feedback:** local tools can use a control socket. They can read status and output or cancel a specific run.
 
 Funzzy has two equivalent binary names: `funzzy` and the shorter `fzz`. This README uses `fzz`.
 
@@ -62,13 +62,13 @@ fzz -- "@quick"           # concise alias for: fzz watch "@quick"
 fzz run "@quick"          # run once and exit
 ```
 
-A secondary worktree can keep finite checks while omitting services:
+A secondary worktree can run checks without starting services:
 
 ```bash
 fzz --no-services -- "@quick"
 ```
 
-Declaration order matters. Only consecutive jobs with the same `parallel` name may overlap; other jobs create serial barriers.
+Declaration order is important. Consecutive jobs with the same `parallel` name can run at the same time. Other jobs run in sequence.
 
 ## Start in one minute
 
@@ -94,24 +94,24 @@ fzz run build                    # finite local run
 fzz                              # start watching
 ```
 
-`fzz init` never overwrites an existing configuration. Use `fzz migrate` to rewrite an accepted legacy configuration into the preferred `jobs:` form.
+`fzz init` does not overwrite an existing configuration. Use `fzz migrate` to convert an accepted old configuration to the `jobs:` form.
 
 > [!NOTE]
 > V2 (`2.0.0`) is the current line. Version 1.5.0 remains on the [`v1` branch](https://github.com/cristianoliveira/funzzy/tree/v1). See the [migration guide](docs/MIGRATION.md).
 
-## Mental model
+## How it works
 
-- A filesystem batch creates one numbered **generation**.
-- Matching jobs form an ordered plan. Consecutive named parallel groups may overlap.
-- A newer generation can wait for or replace active work according to the busy policy.
-- Finite job timeouts terminate and reap the complete process group.
-- Service readiness settles startup; service health remains a separate status view.
-- Valid configuration changes reload in place. Invalid changes fail visibly instead of keeping stale behavior.
-- Control clients operate on exact generations, so freshness is explicit.
+- Funzzy groups file events into a batch. Each batch gets a **generation** number.
+- Matching jobs form an ordered plan. Consecutive jobs in the same named group can run in parallel.
+- The busy policy controls what happens when a new generation starts. Funzzy waits for active work or replaces it.
+- A finite job must exit. Its timeout stops and reaps the complete process group.
+- A readiness check confirms service startup. Service health then has a separate status.
+- Funzzy reloads valid configuration changes. It stops with a clear error for an invalid change.
+- Control clients use an exact generation number. This number identifies one result.
 
-## Humans and agents use the same loop
+## People and agents use the same loop
 
-Humans can watch terminal output and press **Ctrl-G** to trigger the full pipeline. Automation can use the control socket:
+You can read terminal output and press **Ctrl-G** to start all configured jobs. An agent can use the control socket:
 
 ```bash
 fzz ctl capabilities --format toon
@@ -120,7 +120,7 @@ fzz ctl run "@quick" --wait --timeout 5m --format toon
 fzz ctl output --generation 12 --tail 80 --format toon
 ```
 
-Funzzy remains local and provider-neutral. It runs your commands; scripts own external services, credentials, and provider-specific polling.
+Funzzy runs local commands and does not depend on a CI provider. Your scripts manage external services, credentials, and provider requests.
 
 ## Learn more
 
@@ -139,7 +139,7 @@ Funzzy remains local and provider-neutral. It runs your commands; scripts own ex
 
 ## Why it exists
 
-Traditional watchers optimize for a person reading a terminal. Coding agents also need exact run identity, freshness, bounded evidence, and safe cancellation. Funzzy provides both without replacing the fast local workflow developers already know.
+Traditional file watchers show output in a terminal. Coding agents also need an exact run number, current results, short failure output, and safe cancellation. Funzzy provides these functions in the same local workflow.
 
 Inspired by [antr](https://github.com/juanibiapina/antr) and [entr](https://github.com/eradman/entr).
 

--- a/README.md
+++ b/README.md
@@ -1,54 +1,39 @@
-# funzzy (fzz) [![Crate version](https://img.shields.io/crates/v/funzzy.svg?)](https://crates.io/crates/funzzy) [![Building package with nix](https://github.com/cristianoliveira/funzzy/actions/workflows/on-push-nixbuild.yml/badge.svg)](https://github.com/cristianoliveira/funzzy/actions/workflows/on-push-nixbuild.yml) [![CI integration tests](https://github.com/cristianoliveira/funzzy/actions/workflows/on-push-integration-test.yml/badge.svg)](https://github.com/cristianoliveira/funzzy/actions/workflows/on-push-integration-test.yml) [![CI Checks](https://github.com/cristianoliveira/funzzy/actions/workflows/on-push.yml/badge.svg)](https://github.com/cristianoliveira/funzzy/actions/workflows/on-push.yml)
+# Funzzy (`fzz`)
 
-**Funzzy gives developers and coding agents one reliable edit loop:** define checks once, run them on every change, and inspect exact, fresh results.
+[![Crate version](https://img.shields.io/crates/v/funzzy.svg)](https://crates.io/crates/funzzy)
+[![CI Checks](https://github.com/cristianoliveira/funzzy/actions/workflows/on-push.yml/badge.svg)](https://github.com/cristianoliveira/funzzy/actions/workflows/on-push.yml)
+[![Integration tests](https://github.com/cristianoliveira/funzzy/actions/workflows/on-push-integration-test.yml/badge.svg)](https://github.com/cristianoliveira/funzzy/actions/workflows/on-push-integration-test.yml)
+[![Nix build](https://github.com/cristianoliveira/funzzy/actions/workflows/on-push-nixbuild.yml/badge.svg)](https://github.com/cristianoliveira/funzzy/actions/workflows/on-push-nixbuild.yml)
 
-Funzzy (`fzz`) is a fast Rust watcher for the agentic coding era. It runs local workflows as code changes and exposes cancellation and bounded failure output—without log scraping or stale green results.
+**One reliable edit loop for developers and coding agents.**
 
-One YAML workflow works for local development, CI, editors, and coding agents. Use `fzz run TARGET` for finite execution or control a running watcher through a deterministic, machine-readable API.
+Funzzy is a fast Rust file watcher and local workflow runner. Define checks once, run them when files change, and inspect the exact result without scraping logs or trusting stale green output.
 
-## The short version
-
-Funzzy is a good fit when your checks need to be both fast for humans and trustworthy for automation:
-
-- **Reuse one workflow.** Define checks once and watch, run, or inspect them with the same configuration.
-- **Trust each result.** Debouncing, ordered concurrency, exact generations, cancellation, and bounded evidence make outcomes reproducible and actionable.
-- **Discover the contract.** The installed binary generates the schema and examples, so configuration does not depend on stale documentation.
-
-Start with [Quick start](#quick-start), then use the [advanced guide](docs/ADVANCED-GUIDE.md) for control-socket and agent workflows.
-
-```bash
-fzz init    # create .watch.yaml
-fzz check   # validate it
-fzz         # watch, run, repeat
+```text
+edit -> match changed paths -> run configured jobs -> inspect fresh result -> repeat
 ```
 
-> [!WARNING]
-> V2 (2.0.0) is the current line. v1.5.0 remains on the [`v1` branch](https://github.com/cristianoliveira/funzzy/tree/v1); see [docs/MIGRATION.md](docs/MIGRATION.md) for the flag and config mapping.
+## Why Funzzy?
 
+- **One workflow:** use the same YAML for watching, one-shot local runs, editors, CI, and agents.
+- **Predictable execution:** declaration order, explicit parallel groups, debounced generations, cancellation, and process-tree cleanup.
+- **Useful long-running services:** readiness-enabled services can stay alive after their startup generation settles.
+- **Exact feedback:** a local control socket exposes current status, generation identity, bounded output, and cancellation.
 
-For a workflow as simple as:
+Funzzy has two equivalent binary names: `funzzy` and the shorter `fzz`. This README uses `fzz`.
 
-```bash
-find . -name '*.ts' | fzz exec -- npx eslint {{relative_filepath}}
-```
+## A quick glimpse
 
-Or for more complex workflows like:
+Create `.watch.yaml`:
+
 ```yaml
-# .watch.yml
 on:
   change: ["src/**", "tests/**"]
-  ignore: ["target/**", "**/*.log"]
-  debounce: 500ms
+  ignore: ["target/**"]
   socket: .tmp/funzzy/control.sock
 
 execution:
   concurrency: 2
-  recovery_policy: prompt # prompt | skip; default prompt
-  recovery_timeout: 60s # approval-only bound; default 60s
-
-hooks:
-  success: "notify-send 'checks passed'"
-  failure: "notify-send 'checks failed'"
 
 jobs:
   - name: lint @quick
@@ -62,446 +47,102 @@ jobs:
   - name: dev-server
     service: true
     run: cargo run
-    change: "src/**"
+    readiness:
+      run: curl --fail http://127.0.0.1:3000/health
+      timeout: 30s
+      interval: 500ms
 ```
 
-Declaration order is semantic. Only consecutive jobs with same `parallel` name overlap; ordinary jobs create serial barriers. Legacy root task lists and grouped `tasks:` configs remain accepted and can be rewritten with `fzz migrate`.
-
-## Why Funzzy works for humans and agents
-
-Funzzy earns trust by combining a simple edit loop with explicit execution semantics:
-
-- **Reuse one workflow:** use the same workflow locally, in CI, or in an editor feedback loop.
-- **Match changes precisely:** combine change and ignore globs, optional gitignore rules, path templates, and future-file discovery.
-- **Batch deterministically:** debounce and deduplicate filesystem events before creating one generation.
-- **Control execution:** run consecutive named parallel groups behind explicit serial barriers; use `--sequential` for comparison; cancel and reap complete process groups; use readiness-enabled `service: true` jobs when startup health should settle a generation, while services without readiness retain legacy unbounded behavior.
-- **Bound finite work:** `jobs[].timeout` terminates timed-out process trees and records the typed `timedout` outcome; control `--timeout` only bounds the caller's wait.
-- **Automate safely:** run generation-level `hooks.success` and `hooks.failure` without changing the workflow result; optionally run a declared recovery once after an approved failure, then verify the original job; unanswered approval fails after `execution.recovery_timeout` (60s by default), while CI can use `--recovery-policy skip`.
-- **Reload visibly:** valid config changes hot-reload without replacing watcher identity; invalid changes fail visibly instead of leaving stale behavior running.
-- **Inspect exact evidence:** query capabilities, status, targets, exact generations, retained output, duration estimates, cancellation, and fresh terminal results over a permission-restricted Unix socket; status keeps terminal generation outcome primary and exposes pooled services as secondary `{name,state}` entries.
-- **Keep execution observable:** mirror logs and append schema-versioned NDJSON events for runs, tasks, groups, and hooks; managed-service state is intentionally read through control status/await/subscription in the MVP.
-- **Keep configuration discoverable:** generate schema and examples from the installed binary, then validate with the same parser the watcher uses.
-- **Close cleanly:** `hooks.close` runs one finite cleanup command when a ready watcher shuts down gracefully.
-
-## Learn more
-
-
-- [Getting started and daily workflows](docs/USAGE.md)
-- [Advanced control and agent workflows](docs/ADVANCED-GUIDE.md)
-- [V1 to V2 migration](docs/MIGRATION.md)
-- [Configuration schema and agent discovery](docs/AGENT-CONFIG-CONTRACT.md)
-- [User-approved job recovery contract](docs/JOB-RECOVERY-CONTRACT.md)
-- [Current-run job duration report contract](docs/CURRENT-RUN-JOB-DURATION-REPORT-CONTRACT.md)
-- [Dependency inventory and update policy](docs/DEPENDENCY-POLICY.md)
-- [Pi watcher extension](pi-watcher/README.md)
-- [Examples](examples/README.md)
-
-## Enhance your workflows
-
-Funzzy pairs well with these tools:
-
- - [yq](https://github.com/mikefarah/yq) - A yaml querier similar to `jq` to extract commands from GitHub Actions!
-
- - [nrr](https://github.com/ryanccn/nrr) - For JS/TS projects, since Funzzy runs commands on change, a faster task runner makes a difference
-
-## Why it exists
-
-Traditional watchers are optimized for human watching terminal output. Agentic coding also needs exact run identity, freshness, cancellation, structured state, and bounded evidence—without replacing the fast local workflow developers already use.
-
-Funzzy brings GitHub Actions-like checks into the local edit loop and makes that loop observable by both humans and coding agents. Rust keeps watcher fast and lightweight.
-
-Funzzy is inspired by [antr](https://github.com/juanibiapina/antr) and [entr](https://github.com/eradman/entr).
-
-## Install Funzzy
-
-### OSX:
+Then use one of four paths:
 
 ```bash
-brew install funzzy
+fzz check                 # validate without running anything
+fzz                       # watch the complete workflow
+fzz -- "@quick"           # concise alias for: fzz watch "@quick"
+fzz run "@quick"          # run once and exit
 ```
 
-[Latest release](https://github.com/cristianoliveira/funzzy/releases):
+A secondary worktree can keep finite checks while omitting services:
+
+```bash
+fzz --no-services -- "@quick"
+```
+
+Declaration order matters. Only consecutive jobs with the same `parallel` name may overlap; other jobs create serial barriers.
+
+## Start in one minute
+
+Install Funzzy with one of these commands:
+
 ```bash
 brew install cristianoliveira/tap/funzzy
-```
-
-### Linux:
-
-```bash
+cargo install funzzy
 curl -s https://raw.githubusercontent.com/cristianoliveira/funzzy/main/linux-install.sh | sh
 ```
 
-The installer detects the architecture (x86_64/aarch64), verifies the
-published sha256 checksum, and installs both `funzzy` and `fzz` into
-`/usr/local/bin`. You can pin a release:
+See [Installation](docs/INSTALLATION.md) for Nix, pinned releases, source builds, and platform details.
+
+Create and inspect a workflow:
 
 ```bash
-curl -s https://raw.githubusercontent.com/cristianoliveira/funzzy/main/linux-install.sh | bash - 2.0.0
+fzz init                         # create a commented .watch.yaml
+fzz config example minimal       # print a small runnable example
+fzz config schema                # print the current JSON Schema
+fzz check                        # validate with the production parser
+fzz list                         # list configured targets
+fzz run build                    # finite local run
+fzz                              # start watching
 ```
 
-### Nix
+`fzz init` never overwrites an existing configuration. Use `fzz migrate` to rewrite an accepted legacy configuration into the preferred `jobs:` form.
 
-```bash
-nix-env -iA nixpkgs.funzzy
-```
+> [!NOTE]
+> V2 (`2.0.0`) is the current line. Version 1.5.0 remains on the [`v1` branch](https://github.com/cristianoliveira/funzzy/tree/v1). See the [migration guide](docs/MIGRATION.md).
 
-[Latest release](https://github.com/cristianoliveira/funzzy/releases):
-```bash
-nix profile install 'github:cristianoliveira/funzzy'
-# or
-nix profile install 'github:cristianoliveira/nixpkgs#funzzy'
-```
+## Mental model
 
-Install nightly version:
-```bash
-nix profile install 'github:cristianoliveira/funzzy#nightly'
-```
+- A filesystem batch creates one numbered **generation**.
+- Matching jobs form an ordered plan. Consecutive named parallel groups may overlap.
+- A newer generation can wait for or replace active work according to the busy policy.
+- Finite job timeouts terminate and reap the complete process group.
+- Service readiness settles startup; service health remains a separate status view.
+- Valid configuration changes reload in place. Invalid changes fail visibly instead of keeping stale behavior.
+- Control clients operate on exact generations, so freshness is explicit.
 
-or, if you use `shell.nix`:
+## Humans and agents use the same loop
 
-  ```nix
-{ pkgs ? import <nixpkgs> {} }:
-  pkgs.mkShell {
-    buildInputs = [
-      pkgs.funzzy
-    ];
-  };
-```
-
-### With Cargo
-
-```bash
-cargo install funzzy
-```
-
-\*Make sure you have `$HOME/.cargo/bin` in your PATH
-`export PATH=$HOME/.cargo/bin:$PATH`
-
-- From source
-
-Make sure you have installed the following dependencies:
-
-- Rust (>= 1.97, the minimum supported version — declared as `rust-version` in `Cargo.toml`)
-- Cargo
-
-Execute:
-```
-cargo install --git https://github.com/cristianoliveira/funzzy.git
-```
-
-Or, clone this repo and run:
-
-```bash
-make install
-```
-
-## Quick start
-
-Create a config, validate it, run once, then watch — the five-step path
-([full guide](docs/USAGE.md)):
-
-```bash
-fzz init                       # write a runnable .watch.yaml
-fzz check                      # validate (same parser as the watcher)
-fzz list                       # see the configured targets
-fzz run build                  # run the exact target once, no watcher
-fzz                            # zero-argument configured watch
-fzz watch --no-services        # watch finite checks without managed services
-# While watching, press Ctrl-G (0x07) to run the complete pipeline once.
-```
-
-The file `fzz init` writes is a **comprehensive commented starter**: a small
-active hello/change example that runs immediately, plus every supported
-setting documented as a comment next to its owning section (the same
-metadata drives `fzz config schema`). Uncomment any documented example to
-activate it; `fzz init && fzz` is the zero-dependency trial.
-
-Both binary names work — `funzzy` and its short alias `fzz`; examples use
-`fzz`. `fzz init` is create-only (it refuses an existing `.watch.yaml`);
-pick a starter with `fzz init --template minimal|parallel|agent`. Rewrite a
-legacy task-list config with `fzz migrate` (emits the preferred `jobs:`
-form, atomically and idempotently). The installed binary is the config
-reference: `fzz config schema` prints the JSON Schema and
-`fzz config example minimal` prints a runnable example straight from
-the parser.
-
-### Options
-
-Check all the options with `fzz --help`
-
-Use a different config file:
-
-```bash
-fzz -c ~/watch.yaml
-```
-
-Fail fast stops execution when any task fails. Use it when later work depends
-on every earlier task succeeding. [See its usage in our workflow](https://github.com/cristianoliveira/funzzy/blob/main/.watch.yaml#L6)
-
-```bash
-fzz --fail-fast # or fzz -b (bail)
-```
-
-Filtering tasks by target:
-
-```bash
-fzz list
-fzz watch "@quick"
-fzz -- "@quick"       # explicit watch shorthand; target follows `--`
-# Assuming one or more tasks contain `@quick`, only those tasks are watched.
-# `fzz --` alone keeps the zero-argument watch behavior.
-```
-
-### Keyboard trigger
-
-While `fzz` is watching, press **Ctrl-G** once to run the complete configured
-pipeline through the same scheduler used by normal watcher triggers. A press
-while a generation is running is latched and fires once after it finishes;
-additional presses are ignored. Ctrl-C remains SIGINT shutdown. This shortcut
-is available in both blocking and non-block watch modes. Piped stdin is also
-supported (the same Ctrl-G byte triggers the run); closed stdin is consumed
-safely and produces no shortcut.
-
-Validate the configuration without starting a watcher:
-
-```bash
-fzz check
-# Loads the same parser/validator the watcher uses: schema, globs, durations,
-# concurrency, parallel groups, and path existence. Never runs tasks or opens
-# a socket. Exit 0 when valid, non-zero with actionable errors when not.
-```
-
-Run same configured workflow once, without watcher or control socket:
-
-```bash
-fzz run "@quick"
-# Exits with combined configured task outcome; useful in CI.
-```
-
-### Current-run job durations
-
-Every finite local run prints one `JOB / RESULT / DURATION` row per configured
-job in declaration order. A row's duration is that job's monotonic elapsed
-runtime; it remains meaningful for both serial and parallel jobs. The final
-`Duration:` is the separate generation wall time, never a sum of job rows.
-
-A cancelled job that started reports its partial duration. A skipped or
-never-started job prints `-` (`durationMs: null` in structured snapshots). A
-recovered job has one final row whose duration includes recovery and
-verification. A readiness-enabled service records duration through readiness
-promotion; later uptime belongs to its pooled service state. Use the control
-snapshot or NDJSON `task_terminal` event when an exact integer `durationMs` is
-needed.
-
-Inspect or control a watcher configured with `on.socket`:
+Humans can watch terminal output and press **Ctrl-G** to trigger the full pipeline. Automation can use the control socket:
 
 ```bash
 fzz ctl capabilities --format toon
 fzz ctl status --format toon
 fzz ctl run "@quick" --wait --timeout 5m --format toon
+fzz ctl output --generation 12 --tail 80 --format toon
 ```
 
-Run an arbitrary argv over paths from stdin:
+Funzzy remains local and provider-neutral. It runs your commands; scripts own external services, credentials, and provider-specific polling.
 
-```bash
-find . -name '*.rs' | fzz exec -- cargo build
-find . -name '*.[jt]s' | fzz exec -- npx eslint {{filepath}}
-```
+## Learn more
 
-Funzzy does not implicitly invoke a shell for `exec`; use `fzz exec -- sh -c '...'` when shell operators are required.
+| Need | Guide |
+| --- | --- |
+| Installation and upgrades | [Installation](docs/INSTALLATION.md) |
+| First workflow and daily commands | [Usage](docs/USAGE.md) |
+| Control socket, agents, parallelism, and troubleshooting | [Advanced guide](docs/ADVANCED-GUIDE.md) |
+| V1 to V2 changes | [Migration](docs/MIGRATION.md) |
+| Service lifecycle and readiness | [Service lifecycle contract](docs/SERVICE-LIFECYCLE-CONTRACT.md) |
+| Job recovery | [Recovery contract](docs/JOB-RECOVERY-CONTRACT.md) |
+| Configuration discovery for agents | [Agent configuration contract](docs/AGENT-CONFIG-CONTRACT.md) |
+| Example workflows | [Examples](examples/README.md) |
+| Pi integration | [pi-watcher](pi-watcher/README.md) |
+| Development and pull requests | [Contributing](CONTRIBUTING.md) |
 
-Restart busy policy cancels and reaps active work when a newer change batch arrives.
-It is useful for long-running workflows. [See more in long task test](https://github.com/cristianoliveira/funzzy/blob/main/tests/watching_with_non_block_flag.rs#L7)
+## Why it exists
 
-```bash
-fzz --on-busy restart # or fzz --restart
-```
+Traditional watchers optimize for a person reading a terminal. Coding agents also need exact run identity, freshness, bounded evidence, and safe cancellation. Funzzy provides both without replacing the fast local workflow developers already know.
 
-## Event batching and debounce
+Inspired by [antr](https://github.com/juanibiapina/antr) and [entr](https://github.com/eradman/entr).
 
-Filesystem events are collapsed into batches: one debounce window maps to one
-generation, so a burst of writes to several files runs matching tasks **once**
-per batch, not once per duplicate event. The window defaults to one second and
-is configurable with `on.debounce`:
+## License
 
-```yaml
-on:
-  debounce: 500ms   # <number> seconds, or <number>ms/s/m; default 1s
-```
-
-Rules:
-
-- One batch preserves the complete normalized changed-path set (deduplicated,
-deterministically ordered) and the stable event kind.
-- Matching runs once per batch, never once per duplicate backend event.
-- Templates expose the trigger path as `{{filepath}}` (backward compatible)
-and the full batch as `{{paths}}` (shell-escaped, space-joined).
-- `control emit` is an **explicit immediate event**: it routes through the
-same matching and busy-run policy as a native batch but does not wait for the
-debounce window.
-- Invalid `on.debounce` values (zero, negative, unknown suffix) fail loudly;
-they never silently change timing.
-
-## Filesystem backend policy
-
-By default Funzzy uses the native filesystem backend and **automatically falls
-back to deterministic polling** if native watch registration fails (containers,
-network filesystems, WSL, unusual platforms). You can force a backend:
-
-```yaml
-on:
-  watch_backend: auto     # native first, poll fallback (default)
-  # watch_backend: native  # fail clearly if native is unavailable
-  # watch_backend: poll    # always poll
-  poll_interval: 200ms    # used with poll; default 500ms
-```
-
-Polling scans watched roots for create/modify/remove changes on a fixed
-interval and feeds the exact same batching, matching, and execution path as
-the native backend. Tradeoffs: polling adds a small per-interval scan cost and
-change latency up to the interval; prefer native for large trees. Forced
-native fails with an actionable error instead of silently changing semantics.
-
-## Agents and configuration discovery
-
-Agents (and humans) discover the current configuration surface from the
-**installed binary**, never from stale docs. Bootstrap commands:
-
-```sh
-fzz config schema                    # full JSON Schema for the preferred jobs: format
-fzz config schema --section parallel # one bounded section + hint for the full schema
-fzz config example minimal           # runnable minimal .watch.yaml
-fzz config example agent             # control-socket + verify-style example
-fzz check                            # validate .watch.yaml (semantic checks)
-fzz list | fzz explain PATH          # inspect what would run
-fzz run TARGET | fzz watch           # execute
-```
-
-All `config` commands are non-interactive and side-effect-free: they never
-read a project config, start a watcher, open a socket, or run tasks. The
-schema is the single source of truth for structure; `fzz check` adds semantic
-validation. Legacy root-list configs remain accepted and are rewritten with `fzz migrate`.
-
-```yaml
-hooks:
-  success: ./scripts/notify-success   # once per passing generation
-  failure:
-    run: ./scripts/notify-failure     # delayed failure notification
-    settle: 30s                       # only if this failure stays latest
-  close: ./scripts/cleanup             # once per graceful ready-watcher close
-```
-
-The scalar `failure: ./scripts/notify-failure` form remains available for an
-immediate notification. Settled hooks observe watcher generations, not agent
-activity. Generation hooks receive exact `FUNZZY_GENERATION_ID` and
-`FUNZZY_GENERATION_OUTCOME` environment variables; use the ID to retrieve
-retained evidence before forwarding it to a user-owned transport. See [run and watcher hook lifecycle](docs/RUN-HOOKS-CONTRACT.md)
-for invocation, signal, timeout, reload, and exit-code semantics.
-
-## Parallel execution
-
-Funzzy can run independent tasks concurrently. Concurrency is **opt-in**: a
-task belongs to a named `parallel` group, and only *consecutive* tasks sharing
-the same group name may overlap. This keeps existing sequential configs
-running exactly as before — no migration needed.
-
-```yaml
-on:
-  change: "src/**"
-execution:
-  concurrency: 4      # optional global cap on active tasks
-jobs:
-  - name: lint
-    parallel: checks  # group membership is explicit
-    run: cargo clippy
-  - name: test
-    parallel: checks
-    run: cargo test
-  - name: package
-    run: cargo build   # serial: runs alone, after the group
-```
-
-## Finite job execution deadlines
-
-Use `execution.timeout` to set a default for finite jobs; an individual `jobs[].timeout` overrides it. Managed services remain unbounded. To bound a finite job's complete invocation:
-
-```yaml
-execution:
-  timeout: 10m          # default for finite jobs
-jobs:
-  - name: lint
-    run: cargo clippy    # inherits 10m
-  - name: await-remote
-    trigger: manual
-    timeout: 30m          # job override wins
-    run: ./scripts/await-remote.sh
-```
-
-The execution timeout starts at the first successful spawn. When it elapses,
-Funzzy terminates the complete process group (graceful `SIGTERM`, escalating
-to `SIGKILL` when needed), reaps it, retains bounded output, and records the
-job's typed `timedout` state in the failed generation. Use the exact generation
-with `fzz control output --generation N` to retrieve pre-termination evidence.
-
-This is separate from control `--timeout`: that option bounds only how long a
-caller waits for `control await` or `control run --wait`; it never terminates
-the child. A timeout in the job configuration owns child lifetime, while a
-client timeout owns caller patience. See the full provider-neutral recipe in
-[the advanced guide](docs/ADVANCED-GUIDE.md).
-
-## Troubleshooting
-
-#### Why the watcher is running the same task multiple times?
-
-This might be due to different causes, the most common issue when using VIM is because of its default backup setting
-which causes changes to multiple files on save. (See [Why does Vim save files with a ~ extension?](https://stackoverflow.com/questions/607435/why-does-vim-save-files-with-a-extension/607474#607474)).
-For such cases either disable the backup or [ignore them in your watch rules](https://github.com/cristianoliveira/funzzy/blob/main/examples/jobs-with-long-running-commands.yaml#L5).
-
-For other cases use the verbose `fzz -V | grep 'Triggered by'` to understand what is triggering a task to be executed.
-
-## Automated tests
-
-Running unit tests:
-
-```bash
-cargo test
-```
-
-or simple `make tests`
-
-Running integration tests:
-
-```
-make integration
-```
-
-## Code Style
-
-We use `rustfmt` to format the code. To format the code run:
-
-```bash
-cargo fmt
-```
-
-## Contributing
-
-- Fork it!
-- Create your feature branch: `git checkout -b my-new-feature`
-- Commit your changes: `git commit -am 'Add some feature'`
-- Push to the branch: `git push origin my-new-feature`
-- Submit a pull request
-
-### Want to help?
-
- - Open pull requests
- - Create Issues
- - Report bugs
- - Suggest new features or enhancements
-
-Any help is appreciated!
-
-**Pull Request should have unit tests**
-
-# License
-
-This project was made under MIT License.
+[MIT](LICENSE)

--- a/docs/ADVANCED-GUIDE.md
+++ b/docs/ADVANCED-GUIDE.md
@@ -190,6 +190,9 @@ the `legacy` profile, never assumed facts.
 | Config reload | see §6.1 — four distinct behaviors, never guess from a single symptom |
 | Corrupt history | state file damaged → delete to reset, or rely on confidence=None |
 | Feedback loop | watcher noise from generated files → `ignore` or `respect_gitignore: true` |
+| Task runs more than expected after one editor save | backup or temporary files also matched → inspect with `fzz -v` / `fzz explain PATH`, then add a precise `ignore` rule |
+
+Editors that create backup siblings—such as Vim `~` files—can produce several legitimate filesystem events for one save. Funzzy deduplicates one batch, but distinct matching paths remain distinct facts. Prefer ignoring the generated filename pattern rather than disabling event handling.
 
 ### 6.1 Config reload — four distinct behaviors
 

--- a/docs/ADVANCED-GUIDE.md
+++ b/docs/ADVANCED-GUIDE.md
@@ -192,7 +192,7 @@ the `legacy` profile, never assumed facts.
 | Feedback loop | watcher noise from generated files → `ignore` or `respect_gitignore: true` |
 | Task runs more than expected after one editor save | backup or temporary files also matched → inspect with `fzz -v` / `fzz explain PATH`, then add a precise `ignore` rule |
 
-Editors that create backup siblings—such as Vim `~` files—can produce several legitimate filesystem events for one save. Funzzy deduplicates one batch, but distinct matching paths remain distinct facts. Prefer ignoring the generated filename pattern rather than disabling event handling.
+Some editors create a backup file when you save a file. For example, Vim can create a file that ends in `~`. One save can therefore cause events for different paths. Funzzy removes duplicate events for one path, but it keeps events for different paths. Add the generated file pattern to `ignore`. Do not disable event handling.
 
 ### 6.1 Config reload — four distinct behaviors
 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -1,0 +1,100 @@
+# Install Funzzy
+
+Funzzy installs two equivalent binaries: `funzzy` and `fzz`.
+
+## macOS
+
+Stable Homebrew package:
+
+```bash
+brew install funzzy
+```
+
+Latest project release:
+
+```bash
+brew install cristianoliveira/tap/funzzy
+```
+
+## Linux
+
+The installer detects `x86_64` or `aarch64`, verifies the published SHA-256 checksum, and installs both binaries into `/usr/local/bin`:
+
+```bash
+curl -s https://raw.githubusercontent.com/cristianoliveira/funzzy/main/linux-install.sh | sh
+```
+
+Pin a release when reproducibility matters:
+
+```bash
+curl -s https://raw.githubusercontent.com/cristianoliveira/funzzy/main/linux-install.sh | bash - 2.0.0
+```
+
+## Nix
+
+From nixpkgs:
+
+```bash
+nix-env -iA nixpkgs.funzzy
+```
+
+Latest project release or package fork:
+
+```bash
+nix profile install 'github:cristianoliveira/funzzy'
+nix profile install 'github:cristianoliveira/nixpkgs#funzzy'
+```
+
+Nightly:
+
+```bash
+nix profile install 'github:cristianoliveira/funzzy#nightly'
+```
+
+In `shell.nix`:
+
+```nix
+{ pkgs ? import <nixpkgs> {} }:
+pkgs.mkShell {
+  buildInputs = [pkgs.funzzy];
+}
+```
+
+## Cargo
+
+```bash
+cargo install funzzy
+```
+
+Ensure Cargo's binary directory is on `PATH`:
+
+```bash
+export PATH="$HOME/.cargo/bin:$PATH"
+```
+
+## From source
+
+Funzzy requires Rust and Cargo. The minimum supported Rust version is declared by `rust-version` in `Cargo.toml`.
+
+Install from GitHub:
+
+```bash
+cargo install --git https://github.com/cristianoliveira/funzzy.git
+```
+
+Or from a clone:
+
+```bash
+git clone https://github.com/cristianoliveira/funzzy.git
+cd funzzy
+make install
+```
+
+## Verify
+
+```bash
+fzz --version
+fzz --help
+```
+
+Continue with the [one-minute start](../README.md#start-in-one-minute) or the complete [usage guide](USAGE.md).

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -18,7 +18,7 @@ brew install cristianoliveira/tap/funzzy
 
 ## Linux
 
-The installer detects `x86_64` or `aarch64`, verifies the published SHA-256 checksum, and installs both binaries into `/usr/local/bin`:
+The installer supports `x86_64` and `aarch64`. It verifies the published SHA-256 checksum. It installs both binaries in `/usr/local/bin`:
 
 ```bash
 curl -s https://raw.githubusercontent.com/cristianoliveira/funzzy/main/linux-install.sh | sh
@@ -74,7 +74,7 @@ export PATH="$HOME/.cargo/bin:$PATH"
 
 ## From source
 
-Funzzy requires Rust and Cargo. The minimum supported Rust version is declared by `rust-version` in `Cargo.toml`.
+Funzzy requires Rust and Cargo. The `rust-version` value in `Cargo.toml` specifies the minimum Rust version.
 
 Install from GitHub:
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -139,6 +139,10 @@ matching a subcommand still invokes that subcommand.
 
 This is the whole loop: config → check → run → watch.
 
+### Trigger the pipeline from the keyboard
+
+While watching, press **Ctrl-G** once to run the complete configured pipeline through the normal scheduler. A press during an active generation is latched and runs once after it finishes; additional presses are ignored. Ctrl-C remains graceful shutdown. Piped stdin accepts the same Ctrl-G byte, and closed stdin is consumed safely.
+
 ## 2. Daily workflow decision table
 
 | Goal | Command | Watcher? | Side effects |

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -141,7 +141,7 @@ This is the whole loop: config → check → run → watch.
 
 ### Trigger the pipeline from the keyboard
 
-While watching, press **Ctrl-G** once to run the complete configured pipeline through the normal scheduler. A press during an active generation is latched and runs once after it finishes; additional presses are ignored. Ctrl-C remains graceful shutdown. Piped stdin accepts the same Ctrl-G byte, and closed stdin is consumed safely.
+While Funzzy watches files, press **Ctrl-G** once to run all configured jobs. If a generation is active, Funzzy saves one request. It starts that request after the active generation finishes. Funzzy ignores more requests during this time. Ctrl-C starts a graceful shutdown. Piped input accepts the same Ctrl-G byte. Closed input does not cause an error.
 
 ## 2. Daily workflow decision table
 


### PR DESCRIPTION
## Problem

The README had grown into a 500-line reference manual. New readers had to cross installation details, advanced lifecycle contracts, troubleshooting, and contributor instructions before getting a clear glimpse of what Funzzy is.

## Changes

- reduce README from 507 to 148 lines;
- keep the product identity, value proposition, quick YAML example, essential commands, mental model, and human/agent workflow;
- add a compact guide map for progressive disclosure;
- move platform and source installation details to `docs/INSTALLATION.md`;
- move development and pull-request guidance to `CONTRIBUTING.md`;
- preserve keyboard-trigger and editor-backup guidance in the usage and advanced guides.

## Verification

- `cargo test --test config_command_workflow --features test-integration --no-default-features -- --nocapture`: 6 passed
- Markdown target check: passed
- `cargo fmt -- --check`: passed
- `git diff --check`: passed
- independent product/information-architecture review: accepted
