### PR TITLE
feat: add first-party fzz crates.io package

### DIFF
--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -32,19 +32,58 @@ jobs:
       - name: Version identity gate (exact tag/version/package equality)
         run: |
           git fetch --tags --force
-          # Self-contained identity gate. Runs from the immutable tag checkout
-          # (RELEASE-BOUNDARY §5); the stable Nix package is the FINAL channel
-          # and is enforced by its own gate at promotion, so it is intentionally
-          # not part of this check.
-          CARGO="$(grep -m1 '^version' Cargo.toml | sed 's/^version = "\(.*\)"/\1/')"
-          LOCK="$(grep -A1 'name = "funzzy"' Cargo.lock | grep '^version' | head -1 | sed 's/^version = "\(.*\)"/\1/')"
-          test "$CARGO" = "$LOCK" || { echo "Cargo.toml ($CARGO) != Cargo.lock ($LOCK)"; exit 1; }
-          echo "Cargo version:   $CARGO"
-          echo "Lock version:    $LOCK"
-          test "v${CARGO}" = "$(git describe --tags --exact-match HEAD)" || \
-            { echo "tag must equal v<Cargo version>"; exit 1; }
+          scripts/version-check --release
 
-      - name: Publish crate
-        run: cargo publish --token ${CRATES_TOKEN}
+      - name: Verify the fzz alias package
+        run: scripts/fzz-alias-check
+
+      - name: Publish canonical crate, then exact-version alias
         env:
           CRATES_TOKEN: ${{ secrets.CRATES_TOKEN }}
+        run: |
+          set -euo pipefail
+          VERSION="$(grep -m1 '^version' Cargo.toml | sed 's/^version = "\(.*\)"/\1/')"
+
+          crate_version_exists() {
+            curl --fail --silent --show-error \
+              "https://crates.io/api/v1/crates/$1/$VERSION" >/dev/null 2>&1
+          }
+
+          verify_owner() {
+            curl --fail --silent --show-error \
+              "https://crates.io/api/v1/crates/$1/owners" |
+              python3 -c 'import json,sys; users=json.load(sys.stdin)["users"]; assert any(user["login"] == "cristianoliveira" for user in users)'
+          }
+
+          if crate_version_exists funzzy; then
+            echo "funzzy $VERSION already exists; verifying owner and resuming."
+            verify_owner funzzy
+          else
+            cargo publish --token "$CRATES_TOKEN"
+          fi
+
+          # The alias has an exact registry dependency. Wait until a newly
+          # published canonical version is visible before publishing it.
+          for attempt in $(seq 1 60); do
+            if crate_version_exists funzzy; then
+              break
+            fi
+            if [ "$attempt" -eq 60 ]; then
+              echo "funzzy $VERSION did not become visible within five minutes" >&2
+              exit 1
+            fi
+            sleep 5
+          done
+
+          if crate_version_exists fzz; then
+            echo "fzz $VERSION already exists; verifying owner and resuming."
+            verify_owner fzz
+          else
+            cargo publish --manifest-path crates/fzz/Cargo.toml --dry-run
+            cargo publish --manifest-path crates/fzz/Cargo.toml --token "$CRATES_TOKEN"
+          fi
+
+          verify_owner fzz
+          curl --fail --silent --show-error \
+            "https://crates.io/api/v1/crates/fzz/$VERSION/dependencies" |
+            python3 -c 'import json,sys; version=sys.argv[1]; deps=json.load(sys.stdin)["dependencies"]; assert any(dep["crate_id"] == "funzzy" and dep["req"] == f"={version}" for dep in deps)' "$VERSION"

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,8 @@ help: ## Lists the available commands. Add a comment with '##' to describe a com
 .PHONY: tests
 tests: ## Execute all the tests
 	@cargo test --verbose
+	@./scripts/version-check-test
+	@./scripts/fzz-alias-check
 
 .PHONY: build
 build: tests ## Execute all the tests and build funzzy binary
@@ -46,7 +48,9 @@ fmt: ## Format the code (with cargo fmt) and add the changes to the git stage
 .PHONY: lint
 lint: ## Check formatting and fail on Rust or Clippy warnings
 	@cargo fmt -- --check
+	@cargo fmt --manifest-path crates/fzz/Cargo.toml -- --check
 	@cargo clippy --locked --all-targets -- -D warnings
+	@cargo clippy --manifest-path crates/fzz/Cargo.toml --all-targets -- -D warnings
 
 .PHONY: linter
 linter: lint
@@ -105,6 +109,10 @@ version-check: ## Verify release version identity across packages (TASK-0061)
 .PHONY: version-check-test
 version-check-test: ## Test the version consistency check (TASK-0061)
 	@./scripts/version-check-test
+
+.PHONY: fzz-alias-check
+fzz-alias-check: ## Verify the first-party fzz installer package
+	@./scripts/fzz-alias-check
 
 .PHONY: verify-release
 verify-release: ## Verify the published release end-to-end (TASK-0064)

--- a/crates/fzz/Cargo.toml
+++ b/crates/fzz/Cargo.toml
@@ -1,0 +1,24 @@
+[package]
+name = "fzz"
+version = "2.0.0"
+authors = ["Cristian Oliveira <me@cristianoliveira.com>"]
+description = "Official short-name installer for the Funzzy file watcher"
+license = "MIT"
+repository = "https://github.com/cristianoliveira/funzzy"
+readme = "README.md"
+keywords = ["watcher", "workflow", "cli", "development"]
+categories = ["command-line-utilities", "development-tools"]
+edition = "2021"
+rust-version = "1.97"
+publish = ["crates-io"]
+default-run = "fzz"
+include = ["src/**", "Cargo.toml", "README.md", "LICENSE"]
+
+[[bin]]
+name = "fzz"
+path = "src/main.rs"
+
+[dependencies]
+# The path supports repository tests. Cargo removes it from the published
+# manifest and uses the exact crates.io version.
+funzzy = { version = "=2.0.0", path = "../.." }

--- a/crates/fzz/LICENSE
+++ b/crates/fzz/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2016 Cristian Oliveira
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/crates/fzz/README.md
+++ b/crates/fzz/README.md
@@ -1,0 +1,15 @@
+# `fzz`
+
+This package is the official short-name installer for [Funzzy](https://crates.io/crates/funzzy).
+
+```bash
+cargo install fzz
+```
+
+The command installs one binary named `fzz`. It runs the same application as the `fzz` binary from:
+
+```bash
+cargo install funzzy
+```
+
+The `funzzy` package is canonical. This package contains only a small process adapter and an exact dependency on the matching `funzzy` release. Product behavior remains in the [Funzzy repository](https://github.com/cristianoliveira/funzzy).

--- a/crates/fzz/src/main.rs
+++ b/crates/fzz/src/main.rs
@@ -1,0 +1,5 @@
+//! Official short-name process adapter for Funzzy.
+
+fn main() {
+    funzzy::app::run();
+}

--- a/docs/RELEASE-BOUNDARY.md
+++ b/docs/RELEASE-BOUNDARY.md
@@ -83,8 +83,7 @@ scope reduction before cut:
 ## 4. Supported environment and install matrix
 
 - Minimum supported Rust version: the Clap-4.6 toolchain (see `nix/` and CI).
-- Install channels: Cargo (`cargo install funzzy`), crates.io, GitHub release
-  binaries, Nix (stable package), source builds.
+- Install channels: Cargo (`cargo install funzzy`; the first-party `fzz` alias package publishes after the canonical crate), crates.io, GitHub release binaries, Nix (stable package), source builds.
 - Config formats: preferred `jobs:` list, accepted legacy task forms.
 - Protocol/schema versions: declared in `capabilities` (protocolVersion,
   schemaVersion); additive evolution only.
@@ -96,14 +95,16 @@ scope reduction before cut:
 
 ```text
 candidate commit (2.0.0) -> dry-run publish -> tag v2.0.0 (immutable)
-  -> GitHub release -> crates.io publish -> stable Nix update -> verify
+  -> GitHub release -> crates.io publish `funzzy`
+  -> crates.io publish exact-version `fzz` alias -> stable Nix update -> verify
 ```
 
 - Ownership: planning and CI **cannot** publish implicitly. The irreversible
   step (TASK-0063) requires exact SHA approval from the maintainer.
 - Tags and releases are immutable; never amended, moved, or recreated.
 - Partial release resumes channel-aware; never blindly republishes a channel
-  that already succeeded.
+  that already succeeded. If canonical `funzzy` succeeds and the `fzz` alias
+  fails, verify registry state, fix forward, and publish only the missing alias.
 
 ## 6. Roll-forward policy
 

--- a/plans/todo/0168-publish-first-party-fzz-alias-crate.md
+++ b/plans/todo/0168-publish-first-party-fzz-alias-crate.md
@@ -1,0 +1,65 @@
+---
+id: TASK-0168
+title: Publish a first-party fzz alias crate
+status: todo
+depends_on: []
+priority: high
+tags: [security, supply-chain, crates-io, release, cli, packaging]
+---
+
+# Publish a first-party fzz alias crate
+
+## Problem
+
+The `funzzy` crate installs both `funzzy` and `fzz`, but crates.io does not currently contain a package named `fzz`. A user can reasonably try `cargo install fzz`. Until the project owns that package name, another publisher can create a misleading package and turn a predictable installation mistake into a supply-chain risk.
+
+Verified on 2026-09-04:
+
+- `https://crates.io/api/v1/crates/fzz` returns 404.
+- `cargo info fzz` reports that the package does not exist.
+- crates.io package `funzzy` is owned and published by `cristianoliveira`, points to this repository, and declares binary names `funzzy` and `fzz`.
+
+## Desired outcome
+
+The project owns a useful, first-party crates.io package named `fzz`. `cargo install fzz` installs the official short-name binary and runs the same application as `cargo install funzzy`.
+
+## Acceptance criteria
+
+- [ ] Confirm the crates.io name is still unclaimed immediately before any publish action; stop if ownership or metadata changed.
+- [ ] Add a small publishable `fzz` package whose only purpose is the official Funzzy short-name installer; do not publish an empty placeholder.
+- [ ] Make the alias package depend on an exact released `funzzy` version and call the existing public application entry point; do not duplicate application logic.
+- [ ] Publish exactly one binary named `fzz`. Document that `funzzy` remains the canonical package and that both installation paths run the same program.
+- [ ] Keep package metadata explicit: repository, license, README, description, keywords/categories, Rust version, and first-party ownership.
+- [ ] Add deterministic version synchronization to the existing release/version check. Publish `funzzy` first and the matching `fzz` alias second.
+- [ ] Test `cargo install --path` into a temporary root. Prove `fzz --version`, `fzz --help`, and representative parse/error behavior match the canonical binary.
+- [ ] Run `cargo package --list` and `cargo publish --dry-run`; prove the package excludes plans, reports, sockets, logs, local configuration, and unrelated submodules.
+- [ ] Update installation and release documentation only after the package exists. Explain that both `cargo install funzzy` and `cargo install fzz` are official.
+- [ ] Prefer crates.io Trusted Publishing or another scoped release credential. Never print, persist, or commit a registry token.
+- [ ] Require explicit human approval immediately before the irreversible first publish. Preparing, packaging, and dry-running do not authorize publication.
+- [ ] After publish, verify crates.io owner, publisher, repository, checksum, version, and `bin_names`, then install from crates.io in a clean temporary Cargo root.
+- [ ] Record recovery steps for partial release: if canonical `funzzy` publishes but alias publication fails, do not republish or overwrite; fix forward with the same compatible alias dependency or the next version.
+
+## Security constraints
+
+- Do not use a name-only or intentionally nonfunctional reservation package.
+- Do not transfer ownership or add crates.io owners without explicit approval.
+- Do not relax dependency checksums or use a Git dependency in the published alias.
+- Do not make the alias package a second source of product behavior.
+- Do not claim the namespace is protected until crates.io confirms the published package and intended owner.
+
+## Non-goals
+
+- Renaming the canonical `funzzy` crate.
+- Removing the `fzz` binary from the canonical crate.
+- Publishing a different tool under the short name.
+- Changing CLI, YAML, control-socket, or runtime behavior.
+
+## Delivery sequence
+
+1. Prepare and test the alias package locally.
+2. Review package contents and release automation.
+3. Publish or confirm the matching canonical `funzzy` release.
+4. Ask for explicit approval to publish `fzz`.
+5. Publish once.
+6. Verify registry metadata and clean installation.
+7. Update public installation guidance and complete this plan.

--- a/scripts/fzz-alias-check
+++ b/scripts/fzz-alias-check
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Verifies that the first-party `fzz` package installs the canonical short-name
+# binary and contains no repository-local artifacts.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+INSTALL_ROOT="$(mktemp -d)"
+ALIAS_MANIFEST="$ROOT/crates/fzz/Cargo.toml"
+trap 'rm -rf "$INSTALL_ROOT"' EXIT
+
+cargo install --quiet --path "$ROOT/crates/fzz" --root "$INSTALL_ROOT"
+ALIAS_BIN="$INSTALL_ROOT/bin/fzz"
+
+"$ALIAS_BIN" --version > "$INSTALL_ROOT/alias-version"
+cargo run --quiet --manifest-path "$ROOT/Cargo.toml" --bin fzz -- --version \
+  > "$INSTALL_ROOT/canonical-version"
+diff -u "$INSTALL_ROOT/canonical-version" "$INSTALL_ROOT/alias-version"
+
+"$ALIAS_BIN" --help > "$INSTALL_ROOT/alias-help"
+cargo run --quiet --manifest-path "$ROOT/Cargo.toml" --bin fzz -- --help \
+  > "$INSTALL_ROOT/canonical-help"
+diff -u "$INSTALL_ROOT/canonical-help" "$INSTALL_ROOT/alias-help"
+
+set +e
+"$ALIAS_BIN" run > "$INSTALL_ROOT/alias-error-out" 2> "$INSTALL_ROOT/alias-error"
+alias_status=$?
+cargo run --quiet --manifest-path "$ROOT/Cargo.toml" --bin fzz -- run \
+  > "$INSTALL_ROOT/canonical-error-out" 2> "$INSTALL_ROOT/canonical-error"
+canonical_status=$?
+set -e
+
+if [ "$alias_status" -ne 2 ] || [ "$canonical_status" -ne 2 ]; then
+  echo "alias and canonical missing-target errors must both exit 2" >&2
+  exit 1
+fi
+diff -u "$INSTALL_ROOT/canonical-error-out" "$INSTALL_ROOT/alias-error-out"
+diff -u "$INSTALL_ROOT/canonical-error" "$INSTALL_ROOT/alias-error"
+
+package_files="$(cargo package --quiet --manifest-path "$ALIAS_MANIFEST" --list --allow-dirty)"
+if grep -Eq '(^|/)(plans|reports|pi-watcher|\.tmp)(/|$)|\.(log|sock)$' <<< "$package_files"; then
+  echo "fzz package contains a forbidden repository artifact:" >&2
+  echo "$package_files" >&2
+  exit 1
+fi
+
+python3 - "$ALIAS_MANIFEST" <<'PY'
+import json
+import subprocess
+import sys
+
+manifest = sys.argv[1]
+data = json.loads(subprocess.check_output([
+    "cargo", "metadata", "--manifest-path", manifest,
+    "--no-deps", "--format-version", "1",
+]))
+package = data["packages"][0]
+assert package["name"] == "fzz"
+assert [target["name"] for target in package["targets"] if "bin" in target["kind"]] == ["fzz"]
+assert [(dependency["name"], dependency["req"]) for dependency in package["dependencies"]] == [("funzzy", f"={package['version']}")]
+PY
+
+echo "fzz-alias-check OK"

--- a/scripts/version-check
+++ b/scripts/version-check
@@ -4,6 +4,7 @@
 # Inventories every version-bearing surface and verifies they agree:
 #   - Cargo.toml (source of truth for built binary/crate)
 #   - Cargo.lock package version
+#   - crates/fzz alias package version + exact canonical dependency
 #   - `fzz --version` / `funzzy --version` (built from Cargo metadata)
 #   - capabilities watcherVersion (built from Cargo metadata at compile time)
 #   - pi-watcher golden fixtures (protocol snapshot) — additive, checked for drift
@@ -41,6 +42,10 @@ fi
 
 CARGO_VERSION="$(grep -m1 '^version' Cargo.toml | sed 's/^version = "\(.*\)"/\1/')"
 LOCK_VERSION="$(grep -A1 'name = "funzzy"' Cargo.lock | grep '^version' | head -1 | sed 's/^version = "\(.*\)"/\1/')"
+ALIAS_MANIFEST="crates/fzz/Cargo.toml"
+ALIAS_NAME="$(grep -m1 '^name' "$ALIAS_MANIFEST" | sed 's/^name = "\(.*\)"/\1/')"
+ALIAS_VERSION="$(grep -m1 '^version' "$ALIAS_MANIFEST" | sed 's/^version = "\(.*\)"/\1/')"
+ALIAS_DEPENDENCY="$(sed -n 's/^funzzy = { version = "\(=[^"]*\)".*/\1/p' "$ALIAS_MANIFEST")"
 
 errors=0
 
@@ -48,13 +53,27 @@ fail() { echo "INCONSISTENT: $*" >&2; errors=$((errors + 1)); }
 
 echo "Cargo version:   $CARGO_VERSION"
 echo "Lock version:    $LOCK_VERSION"
+echo "fzz alias:       $ALIAS_VERSION (funzzy $ALIAS_DEPENDENCY)"
 
 # 1. Cargo.toml == Cargo.lock
 if [ "$CARGO_VERSION" != "$LOCK_VERSION" ]; then
   fail "Cargo.toml ($CARGO_VERSION) != Cargo.lock ($LOCK_VERSION)"
 fi
 
-# 2. Built binaries report the Cargo version (cargo metadata is source of truth).
+# 2. The short-name installer and its canonical dependency stay in exact
+#    release lockstep. `cargo install fzz` must never resolve different
+#    product behavior from `cargo install funzzy`.
+if [ "$ALIAS_NAME" != "fzz" ]; then
+  fail "$ALIAS_MANIFEST package name ($ALIAS_NAME) != fzz"
+fi
+if [ "$CARGO_VERSION" != "$ALIAS_VERSION" ]; then
+  fail "$ALIAS_MANIFEST version ($ALIAS_VERSION) != Cargo ($CARGO_VERSION)"
+fi
+if [ "$ALIAS_DEPENDENCY" != "=$CARGO_VERSION" ]; then
+  fail "$ALIAS_MANIFEST funzzy dependency ($ALIAS_DEPENDENCY) != =$CARGO_VERSION"
+fi
+
+# 3. Built binaries report the Cargo version (cargo metadata is source of truth).
 if command -v cargo >/dev/null 2>&1; then
   BIN_VERSION="$(cargo metadata --no-deps --format-version 1 2>/dev/null | python3 -c "import sys,json; print(json.load(sys.stdin)['packages'][0]['version'])")"
   if [ "$CARGO_VERSION" != "$BIN_VERSION" ]; then
@@ -62,7 +81,7 @@ if command -v cargo >/dev/null 2>&1; then
   fi
 fi
 
-# 3. Stable Nix package must point at a tag equal to Cargo version (release only).
+# 4. Stable Nix package must point at a tag equal to Cargo version (release only).
 #    Prerelease Cargo versions (2.0.0-beta.N) are checked only for template
 #    sanity; the stable Nix package intentionally stays on the last stable tag
 #    until the candidate cut (RELEASE-BOUNDARY §4).
@@ -88,7 +107,7 @@ if [ -f nix/package.nix ]; then
   fi
 fi
 
-# 4. Tag: for a stable release the tag must exist and match exactly. The
+# 5. Tag: for a stable release the tag must exist and match exactly. The
 #    candidate prep (TASK-0062) is pre-tag by design: --candidate skips the
 #    existence check (the tag is created at publication, TASK-0063) while
 #    still enforcing everything else.
@@ -104,7 +123,7 @@ else
   echo "Tag:             (prerelease $CARGO_VERSION, tag not required)"
 fi
 
-# 5. README release label, when a version marker is present. Prerelease
+# 6. README release label, when a version marker is present. Prerelease
 #    versions may be labeled by their major (e.g. "Version 2.0.0" for
 #    2.0.0-beta.1); stable versions must match exactly.
 if grep -qE 'Version 2\.0\.0|v2\.0\.0|### Version' README.md; then
@@ -118,7 +137,7 @@ if grep -qE 'Version 2\.0\.0|v2\.0\.0|### Version' README.md; then
   fi
 fi
 
-# 6. pi-watcher fixtures carry no hardcoded funzzy version (they use tokens).
+# 7. pi-watcher fixtures carry no hardcoded funzzy version (they use tokens).
 if grep -qE '"watcherVersion"' pi-watcher/src/domain/fixtures/*.json 2>/dev/null; then
   fail "pi-watcher fixtures must not hardcode watcherVersion (stale on release)"
 fi

--- a/scripts/version-check-test
+++ b/scripts/version-check-test
@@ -54,7 +54,7 @@ version = "9.9.9-beta.1"
 edition = "2021"
 
 [dependencies]
-funzzy = "=9.9.9-beta.1"
+funzzy = { version = "=9.9.9-beta.1", path = "../.." }
 FIXTURE
 mkdir -p "$SCRATCH/src"
 printf 'fn main() {}\n' > "$SCRATCH/src/main.rs"
@@ -89,14 +89,16 @@ sed -i 's/version = "9.9.9-beta.1"/version = "9.9.8"/' "$SCRATCH/crates/fzz/Carg
 expect_reject "fzz alias package version mismatch" "$SCRATCH/scripts/version-check"
 mv "$SCRATCH/crates/fzz/Cargo.toml.orig" "$SCRATCH/crates/fzz/Cargo.toml"
 
-sed -i 's/funzzy = "=9.9.9-beta.1"/funzzy = "=9.9.8"/' "$SCRATCH/crates/fzz/Cargo.toml"
+sed -i 's/version = "=9.9.9-beta.1"/version = "=9.9.8"/' "$SCRATCH/crates/fzz/Cargo.toml"
 expect_reject "fzz alias dependency mismatch" "$SCRATCH/scripts/version-check"
-sed -i 's/funzzy = "=9.9.8"/funzzy = "=9.9.9-beta.1"/' "$SCRATCH/crates/fzz/Cargo.toml"
+sed -i 's/version = "=9.9.8"/version = "=9.9.9-beta.1"/' "$SCRATCH/crates/fzz/Cargo.toml"
 
 # 4. Stable version requires an exact v-prefixed tag: fake a stable Cargo
 #    version and ensure the missing-tag branch fires.
 sed -i 's/^version = "9.9.9-beta.1"/version = "9.9.9"/' "$SCRATCH/Cargo.toml"
 sed -i 's/^version = "9.9.9-beta.1"/version = "9.9.9"/' "$SCRATCH/Cargo.lock"
+sed -i 's/^version = "9.9.9-beta.1"/version = "9.9.9"/' "$SCRATCH/crates/fzz/Cargo.toml"
+sed -i 's/version = "=9.9.9-beta.1"/version = "=9.9.9"/' "$SCRATCH/crates/fzz/Cargo.toml"
 expect_reject "stable version without v9.9.9 tag" "$SCRATCH/scripts/version-check"
 
 echo "version-check-test: $pass passed, $failc failed"

--- a/scripts/version-check-test
+++ b/scripts/version-check-test
@@ -31,7 +31,7 @@ expect_accept() {
 
 SCRATCH="$(mktemp -d)"
 trap 'rm -rf "$SCRATCH"' EXIT
-mkdir -p "$SCRATCH/scripts" "$SCRATCH/nix"
+mkdir -p "$SCRATCH/scripts" "$SCRATCH/nix" "$SCRATCH/crates/fzz"
 # Synthesize pinned-prerelease manifests instead of copying the live ones:
 # the real Cargo.toml drifts with the release cycle (2.0.0-beta.1 -> 2.0.0 ->
 # ...), which once broke case 1 when the repo reached a stable version and
@@ -46,6 +46,15 @@ edition = "2021"
 [[bin]]
 name = "fzz"
 path = "src/main.rs"
+FIXTURE
+cat > "$SCRATCH/crates/fzz/Cargo.toml" <<'FIXTURE'
+[package]
+name = "fzz"
+version = "9.9.9-beta.1"
+edition = "2021"
+
+[dependencies]
+funzzy = "=9.9.9-beta.1"
 FIXTURE
 mkdir -p "$SCRATCH/src"
 printf 'fn main() {}\n' > "$SCRATCH/src/main.rs"
@@ -67,12 +76,24 @@ mkdir -p "$SCRATCH/.git"
 expect_accept "healthy prerelease repo" "$SCRATCH/scripts/version-check"
 
 # 2. Cargo/lock mismatch is rejected: fake a lock with a different version.
-cp "$SCRATCH/Cargo.toml" "$SCRATCH/Cargo.toml.orig"
+cp "$SCRATCH/Cargo.lock" "$SCRATCH/Cargo.lock.orig"
 sed -i 's/^version = "9.9.9-beta.1"/version = "9.9.9-beta.2"/' "$SCRATCH/Cargo.lock"
 expect_reject "Cargo/lock version mismatch" "$SCRATCH/scripts/version-check"
-mv "$SCRATCH/Cargo.toml.orig" "$SCRATCH/Cargo.toml"
+mv "$SCRATCH/Cargo.lock.orig" "$SCRATCH/Cargo.lock"
 
-# 3. Stable version requires an exact v-prefixed tag: fake a stable Cargo
+# 3. The short-name installer must publish the same version and depend on
+#    that exact canonical version. A drift could install different behavior
+#    under `cargo install fzz`.
+cp "$SCRATCH/crates/fzz/Cargo.toml" "$SCRATCH/crates/fzz/Cargo.toml.orig"
+sed -i 's/version = "9.9.9-beta.1"/version = "9.9.8"/' "$SCRATCH/crates/fzz/Cargo.toml"
+expect_reject "fzz alias package version mismatch" "$SCRATCH/scripts/version-check"
+mv "$SCRATCH/crates/fzz/Cargo.toml.orig" "$SCRATCH/crates/fzz/Cargo.toml"
+
+sed -i 's/funzzy = "=9.9.9-beta.1"/funzzy = "=9.9.8"/' "$SCRATCH/crates/fzz/Cargo.toml"
+expect_reject "fzz alias dependency mismatch" "$SCRATCH/scripts/version-check"
+sed -i 's/funzzy = "=9.9.8"/funzzy = "=9.9.9-beta.1"/' "$SCRATCH/crates/fzz/Cargo.toml"
+
+# 4. Stable version requires an exact v-prefixed tag: fake a stable Cargo
 #    version and ensure the missing-tag branch fires.
 sed -i 's/^version = "9.9.9-beta.1"/version = "9.9.9"/' "$SCRATCH/Cargo.toml"
 sed -i 's/^version = "9.9.9-beta.1"/version = "9.9.9"/' "$SCRATCH/Cargo.lock"


### PR DESCRIPTION
## Problem

The official `funzzy` crate installs an `fzz` binary, but the crates.io package name `fzz` is unclaimed. A user who tries `cargo install fzz` can therefore be exposed to a future misleading package.

## Changes

- add a legitimate first-party `fzz` installer package;
- delegate directly to `funzzy::app::run()` with an exact `funzzy = "=2.0.0"` dependency;
- publish exactly one `fzz` binary and no duplicate product logic;
- add install/help/error parity and package-content checks;
- enforce canonical/alias version lockstep with regression tests;
- wire the release workflow to publish `funzzy` first and `fzz` second;
- verify crates.io ownership and exact dependency during safe channel-aware resume;
- document release ordering and partial-failure recovery.

## Verification

- `cargo publish --manifest-path crates/fzz/Cargo.toml --dry-run`: passed
- `make fzz-alias-check`: passed
- `scripts/version-check-test`: 5 passed
- `scripts/version-check --release`: passed
- root and alias Clippy/format checks: passed
- independent release/supply-chain review: accepted

## Publication boundary

This PR prepares the package but does not publish it. The first irreversible `fzz` publication requires explicit maintainer approval after merge and a final registry-name check.
