### PR TITLE
test: stabilize future-file burst fixture

### DIFF
--- a/plans/done/0184-make-future-file-burst-fixture-deterministic.md
+++ b/plans/done/0184-make-future-file-burst-fixture-deterministic.md
@@ -1,0 +1,33 @@
+---
+id: TASK-0184
+title: Make future-file burst fixture deterministic
+status: done
+depends_on: []
+priority: normal
+tags: []
+---
+
+# Make future-file burst fixture deterministic
+
+## Problem
+The serialized Linux integration suite can lose the first files when a burst creates a directory and immediately writes files before native recursive child-watch registration completes. The test must isolate batching semantics from that OS registration race.
+
+## Context
+
+CI run `34146177258` failed on Ubuntu at `tests/future_files.rs:379` with only `src/file2.rs`, `src/file3.rs`, and `src/file4.rs` observed. The native watcher registers recursive child directories asynchronously; this test should not combine that registration contract with its debounce-burst assertion. Future-directory behavior remains covered by `directory_burst_after_startup_yields_one_canonical_generation`.
+
+## Acceptance criteria
+
+- [x] Create `src/` before starting the watcher.
+- [x] Keep the five-file one-window changed-set assertion and later-window assertion unchanged in intent.
+- [x] Do not add sleeps or change watcher production behavior.
+- [x] Focused target and serialized `future_files` integration suite pass repeatedly.
+
+## Evidence
+
+- Focused target: 20/20 passed with `--test-threads=1`.
+- Full serialized `future_files` suite: 5/5 passed with `--test-threads=1`.
+- Only `tests/future_files.rs` changes; no production watcher code or sleeps changed.
+
+## Notes
+

--- a/tests/future_files.rs
+++ b/tests/future_files.rs
@@ -352,6 +352,9 @@ fn unmatched_ignored_and_escape_creations_do_not_run_jobs() {
 #[test]
 fn burst_in_one_window_is_one_generation_then_next_window_is_next() {
     let directory = setup_directory("burst", CAPTURE_CONFIG);
+    // Keep this batching assertion independent from native recursive child-watch
+    // registration; future-directory discovery is covered by the dedicated test.
+    std::fs::create_dir_all(directory.join("src")).unwrap();
     let _watcher = start_watcher(&directory);
     wait_until_socket(&directory);
     let socket = directory.join("sock");
@@ -359,7 +362,6 @@ fn burst_in_one_window_is_one_generation_then_next_window_is_next() {
 
     // Write several files rapidly (one debounce window).
     for i in 0..5 {
-        std::fs::create_dir_all(directory.join("src")).unwrap();
         std::fs::write(directory.join(format!("src/file{i}.rs")), "x").unwrap();
     }
     wait_until_or_dump(&directory, &socket, || {


### PR DESCRIPTION
## Problem

CI run 34146177258 intermittently lost the first files in the future-file burst test on Ubuntu. The native recursive child watch for a directory created during the test is registered asynchronously, so the test mixed directory discovery with its debounce-batch assertion.

## Change

Create `src/` before starting the watcher and keep the five rapid file writes focused on one-window batching. Future-directory discovery remains covered by `directory_burst_after_startup_yields_one_canonical_generation`.

This is test-only: no watcher production behavior or sleeps changed.

## Verification

- Focused target, serialized: 20/20 passed.
- Full `future_files` suite, serialized: 5/5 passed.
- Based directly on `origin/main`; standalone TASK-0184.
