### PR TITLE
test: isolate process-owner registry IDs

### DIFF
--- a/plans/done/0185-isolate-process-owner-test-registry-ids.md
+++ b/plans/done/0185-isolate-process-owner-test-registry-ids.md
@@ -1,0 +1,33 @@
+---
+id: TASK-0185
+title: Isolate process-owner test registry IDs
+status: done
+depends_on: []
+priority: normal
+tags: [tests, determinism]
+---
+
+# Isolate process-owner test registry IDs
+
+## Problem
+
+`register_then_unregister_forgets_the_group` and `register_is_idempotent` share registry ID `999_991`. Parallel unit tests can unregister the ID between another test's registration and assertion, making the tests interfere nondeterministically.
+
+## Approach
+
+Give each test its own impossible process-group ID while preserving explicit cleanup and all production registry behavior.
+
+## Acceptance criteria
+
+- [x] The two registry tests use distinct test-local IDs.
+- [x] Explicit unregister cleanup remains in each test.
+- [x] No production code or sleeps change.
+- [x] Repeated process-owner library tests pass.
+- [x] Nix build/check passes when available.
+
+## Evidence
+
+- `cargo test --lib process_owner -- --test-threads=8`: 30/30 runs passed.
+- `cargo fmt --all -- --check`: passed.
+- `make nix-flake-check`: passed.
+- `make nix-build-local`: passed; Nix unit check reported 917 passed, 0 failed.

--- a/src/process_owner.rs
+++ b/src/process_owner.rs
@@ -151,39 +151,40 @@ fn shutdown_signal(value: Option<&str>) -> Signal {
 mod tests {
     use super::*;
 
-    // A PID no real process occupies; unique to this test module so concurrent
-    // cmd/workers tests (which register real PIDs) cannot collide with it.
-    const OWNED_BY_THIS_TEST: i32 = 999_991;
+    // PIDs no real process occupies; unique per test so parallel tests cannot
+    // unregister another test's registry entry between its assertions.
+    const FORGET_GROUP_ID: i32 = 999_991;
+    const IDEMPOTENT_GROUP_ID: i32 = 999_992;
 
     #[test]
     fn register_then_unregister_forgets_the_group() {
-        register(OWNED_BY_THIS_TEST);
+        register(FORGET_GROUP_ID);
         let still_present = OWNED_GROUPS
             .lock()
             .expect("mutex")
-            .contains(&OWNED_BY_THIS_TEST);
+            .contains(&FORGET_GROUP_ID);
         assert!(still_present, "register must track the group");
 
-        unregister(OWNED_BY_THIS_TEST);
+        unregister(FORGET_GROUP_ID);
         let still_there = OWNED_GROUPS
             .lock()
             .expect("mutex")
-            .contains(&OWNED_BY_THIS_TEST);
+            .contains(&FORGET_GROUP_ID);
         assert!(!still_there, "unregister must forget the group");
     }
 
     #[test]
     fn register_is_idempotent() {
-        register(OWNED_BY_THIS_TEST);
-        register(OWNED_BY_THIS_TEST);
+        register(IDEMPOTENT_GROUP_ID);
+        register(IDEMPOTENT_GROUP_ID);
         let count = OWNED_GROUPS
             .lock()
             .expect("mutex")
             .iter()
-            .filter(|&&g| g == OWNED_BY_THIS_TEST)
+            .filter(|&&g| g == IDEMPOTENT_GROUP_ID)
             .count();
         assert_eq!(count, 1, "registering twice must not duplicate");
-        unregister(OWNED_BY_THIS_TEST);
+        unregister(IDEMPOTENT_GROUP_ID);
     }
 
     #[test]


### PR DESCRIPTION
## Problem

`register_then_unregister_forgets_the_group` and `register_is_idempotent` shared registry ID `999_991`. Parallel unit-test execution could unregister that entry between another test's registration and assertion.

## Change

Use distinct impossible process-group IDs for the two tests while preserving explicit cleanup. Production registry behavior is unchanged. TASK-0185 is included and closed in the plan board.

## Verification

- `cargo test --lib process_owner -- --test-threads=8`: 30/30 repeated runs passed.
- `cargo fmt --all -- --check`: passed.
- `make nix-flake-check`: passed.
- `make nix-build-local`: passed; Nix unit check reported 917 passed, 0 failed.
